### PR TITLE
Add Demo Mode with seeded 6‑month lifter data and dashboard toggle

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { Icon, MiniChart, ErrorBoundary } from '@/shared/components';
 import { S, globalCss } from '@/shared/theme/styles';
 import { getGreeting } from '@/shared/utils';
 import { loadProfile, saveProfile, runMigrations } from '@/shared/storage';
+import { DemoModeProvider, useDemoMode } from '@/shared/demo/DemoModeContext';
 import { PlanProvider } from '@/features/training-plan/PlanContext';
 import { WorkoutProvider, useWorkout } from '@/features/workout/WorkoutContext';
 import { NutritionProvider } from '@/features/nutrition/nutrition.context';
@@ -33,15 +34,17 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <PlanProvider profile={profile}>
-        <WorkoutProvider>
-          <NutritionProvider>
-            <ProgressProvider>
-              <AppShell profile={profile} />
-            </ProgressProvider>
-          </NutritionProvider>
-        </WorkoutProvider>
-      </PlanProvider>
+      <DemoModeProvider>
+        <PlanProvider profile={profile}>
+          <WorkoutProvider>
+            <NutritionProvider>
+              <ProgressProvider>
+                <AppShell profile={profile} />
+              </ProgressProvider>
+            </NutritionProvider>
+          </WorkoutProvider>
+        </PlanProvider>
+      </DemoModeProvider>
     </ErrorBoundary>
   );
 }
@@ -55,6 +58,7 @@ function AppShell({ profile }: { profile: UserProfile }) {
   const [showExerciseHistoryFromDash, setShowExerciseHistoryFromDash] = useState<string | null>(null);
   const [celebrate, setCelebrate] = useState(false);
 
+  const demoMode = useDemoMode();
   const workout = useWorkout();
   const progress = useProgress();
 
@@ -140,6 +144,8 @@ function AppShell({ profile }: { profile: UserProfile }) {
             onOpenNutrition={() => setShowNutritionFromDash(true)}
             onOpenMeasurements={() => setShowMeasurements(true)}
             onShowExerciseHistory={setShowExerciseHistoryFromDash}
+            demoMode={demoMode.enabled}
+            onToggleDemo={demoMode.setEnabled}
           />
         )}
       </main>

--- a/src/features/nutrition/nutrition.context.tsx
+++ b/src/features/nutrition/nutrition.context.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { ProteinSource, ProteinLogEntry, NutritionHistory } from '@/shared/types';
 import { getTodayKey } from '@/shared/utils';
 import { loadNutritionHistory, saveNutritionHistory } from '@/shared/storage';
+import { useDemoMode } from '@/shared/demo/DemoModeContext';
 
 interface NutritionContextValue {
   todayWater: number;
@@ -17,19 +18,40 @@ interface NutritionContextValue {
 const NutritionContext = createContext<NutritionContextValue | null>(null);
 
 export function NutritionProvider({ children }: { children: ReactNode }) {
-  const [nutritionHistory, setNutritionHistory] = useState<NutritionHistory>(() => loadNutritionHistory());
+  const demo = useDemoMode();
+  const [nutritionHistory, setNutritionHistory] = useState<NutritionHistory>(() => (
+    demo.enabled ? (demo.demoData?.nutritionHistory ?? {}) : loadNutritionHistory()
+  ));
   const [todayWater, setTodayWater] = useState(() => {
     const today = getTodayKey();
-    return nutritionHistory[today]?.water || 0;
+    return (demo.enabled ? demo.demoData?.nutritionHistory[today]?.water : nutritionHistory[today]?.water) || 0;
   });
   const [todayProtein, setTodayProtein] = useState(() => {
     const today = getTodayKey();
-    return nutritionHistory[today]?.protein || 0;
+    return (demo.enabled ? demo.demoData?.nutritionHistory[today]?.protein : nutritionHistory[today]?.protein) || 0;
   });
   const [proteinLog, setProteinLog] = useState<ProteinLogEntry[]>(() => {
     const today = getTodayKey();
-    return nutritionHistory[today]?.proteinLog || [];
+    return (demo.enabled ? demo.demoData?.nutritionHistory[today]?.proteinLog : nutritionHistory[today]?.proteinLog) || [];
   });
+
+  useEffect(() => {
+    if (demo.enabled) {
+      const history = demo.demoData?.nutritionHistory ?? {};
+      const today = getTodayKey();
+      setNutritionHistory(history);
+      setTodayWater(history[today]?.water || 0);
+      setTodayProtein(history[today]?.protein || 0);
+      setProteinLog(history[today]?.proteinLog || []);
+    } else {
+      const history = loadNutritionHistory();
+      const today = getTodayKey();
+      setNutritionHistory(history);
+      setTodayWater(history[today]?.water || 0);
+      setTodayProtein(history[today]?.protein || 0);
+      setProteinLog(history[today]?.proteinLog || []);
+    }
+  }, [demo.enabled, demo.demoData]);
 
   // Persist nutrition changes
   useEffect(() => {
@@ -40,9 +62,13 @@ export function NutritionProvider({ children }: { children: ReactNode }) {
         [today]: { water: todayWater, protein: todayProtein, proteinLog },
       };
       setNutritionHistory(updated);
-      saveNutritionHistory(updated);
+      if (demo.enabled) {
+        demo.updateDemoData(data => ({ ...data, nutritionHistory: updated }));
+      } else {
+        saveNutritionHistory(updated);
+      }
     }
-  }, [todayWater, todayProtein, proteinLog]);
+  }, [todayWater, todayProtein, proteinLog, demo]);
 
   const addWater = useCallback(() => {
     setTodayWater(w => w + 1);

--- a/src/features/progress/Dashboard.tsx
+++ b/src/features/progress/Dashboard.tsx
@@ -13,9 +13,19 @@ interface DashboardProps {
   onOpenNutrition: () => void;
   onOpenMeasurements: () => void;
   onShowExerciseHistory: (name: string) => void;
+  demoMode: boolean;
+  onToggleDemo: (enabled: boolean) => void;
 }
 
-export function Dashboard({ profile, streak, onOpenNutrition, onOpenMeasurements, onShowExerciseHistory }: DashboardProps) {
+export function Dashboard({
+  profile,
+  streak,
+  onOpenNutrition,
+  onOpenMeasurements,
+  onShowExerciseHistory,
+  demoMode,
+  onToggleDemo,
+}: DashboardProps) {
   const workout = useWorkout();
   const nutrition = useNutrition();
   const progress = useProgress();
@@ -26,6 +36,7 @@ export function Dashboard({ profile, streak, onOpenNutrition, onOpenMeasurements
   const last7 = getLast7Days();
   const proteinData = last7.map(d => nutrition.nutritionHistory[d]?.protein || 0);
   const weightData = progress.bodyMeasurements.slice(-10).map(m => parseFloat(String(m.weight)) || 0);
+  const programsCompleted = Math.floor(workout.weekCount / 4);
 
   return (
     <div>
@@ -42,6 +53,10 @@ export function Dashboard({ profile, streak, onOpenNutrition, onOpenMeasurements
         <div style={S.sumCard}>
           <div style={S.sumLabel}>STREAK</div>
           <div style={S.sumVal}>{streak} 🔥</div>
+        </div>
+        <div style={S.sumCard}>
+          <div style={S.sumLabel}>PROGRAMS</div>
+          <div style={S.sumVal}>{programsCompleted}</div>
         </div>
       </div>
 
@@ -132,6 +147,20 @@ export function Dashboard({ profile, streak, onOpenNutrition, onOpenMeasurements
           <div style={S.profileItem}><span style={S.profileLabel}>Weight</span><span>{profile.weight}kg</span></div>
           <div style={S.profileItem}><span style={S.profileLabel}>Level</span><span style={{ textTransform: 'capitalize' }}>{profile.level}</span></div>
           <div style={S.profileItem}><span style={S.profileLabel}>Schedule</span><span>{profile.days}x/week</span></div>
+        </div>
+        <div style={S.demoRow}>
+          <div>
+            <div style={S.demoLabel}>Demo Mode</div>
+            <div style={S.demoHint}>Load 6 months of serious lifter data</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => onToggleDemo(!demoMode)}
+            style={{ ...S.demoToggle, ...(demoMode ? S.demoToggleOn : {}) }}
+            aria-pressed={demoMode}
+          >
+            <span style={{ ...S.demoKnob, ...(demoMode ? S.demoKnobOn : {}) }} />
+          </button>
         </div>
       </div>
     </div>

--- a/src/features/progress/progress.context.tsx
+++ b/src/features/progress/progress.context.tsx
@@ -1,8 +1,9 @@
-import React, { createContext, useContext, useState, useCallback } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import type { ReactNode } from 'react';
 import type { BodyMeasurement } from '@/shared/types';
 import { getTodayKey } from '@/shared/utils';
 import { loadBodyMeasurements, saveBodyMeasurements } from '@/shared/storage';
+import { useDemoMode } from '@/shared/demo/DemoModeContext';
 
 interface ProgressContextValue {
   bodyMeasurements: BodyMeasurement[];
@@ -12,15 +13,30 @@ interface ProgressContextValue {
 const ProgressContext = createContext<ProgressContextValue | null>(null);
 
 export function ProgressProvider({ children }: { children: ReactNode }) {
-  const [bodyMeasurements, setBodyMeasurements] = useState<BodyMeasurement[]>(() => loadBodyMeasurements());
+  const demo = useDemoMode();
+  const [bodyMeasurements, setBodyMeasurements] = useState<BodyMeasurement[]>(() => (
+    demo.enabled ? (demo.demoData?.bodyMeasurements ?? []) : loadBodyMeasurements()
+  ));
+
+  useEffect(() => {
+    if (demo.enabled) {
+      setBodyMeasurements(demo.demoData?.bodyMeasurements ?? []);
+    } else {
+      setBodyMeasurements(loadBodyMeasurements());
+    }
+  }, [demo.enabled, demo.demoData]);
 
   const saveMeasurement = useCallback((data: Omit<BodyMeasurement, 'date'>) => {
     setBodyMeasurements(prev => {
       const updated = [...prev, { ...data, date: getTodayKey() }];
-      saveBodyMeasurements(updated);
+      if (demo.enabled) {
+        demo.updateDemoData(d => ({ ...d, bodyMeasurements: updated }));
+      } else {
+        saveBodyMeasurements(updated);
+      }
       return updated;
     });
-  }, []);
+  }, [demo]);
 
   return (
     <ProgressContext.Provider value={{ bodyMeasurements, saveMeasurement }}>

--- a/src/features/workout/WorkoutContext.tsx
+++ b/src/features/workout/WorkoutContext.tsx
@@ -1,9 +1,10 @@
-import React, { createContext, useContext, useReducer, useCallback, useState } from 'react';
+import React, { createContext, useContext, useReducer, useCallback, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { RPEValue, PlanExercise, WorkoutLog, ExerciseHistory, PersonalRecords } from '@/shared/types';
 import { workoutReducer, initialWorkoutState } from './workout.reducer';
 import { calculate1RM, getTodayKey, getWeekNumber } from '@/shared/utils';
 import { usePlan } from '@/features/training-plan/PlanContext';
+import { useDemoMode } from '@/shared/demo/DemoModeContext';
 import {
   loadWorkoutHistory, saveWorkoutHistory,
   loadExerciseHistory, saveExerciseHistory,
@@ -34,15 +35,43 @@ const WorkoutContext = createContext<WorkoutContextValue | null>(null);
 
 export function WorkoutProvider({ children }: { children: ReactNode }) {
   const plan = usePlan();
+  const demo = useDemoMode();
   const [state, dispatch] = useReducer(workoutReducer, initialWorkoutState);
 
-  const [workoutHistory, setWorkoutHistory] = useState<WorkoutLog[]>(() => loadWorkoutHistory());
-  const [exerciseHistory, setExerciseHistory] = useState<ExerciseHistory>(() => loadExerciseHistory());
-  const [personalRecords, setPersonalRecords] = useState<PersonalRecords>(() => loadPersonalRecords());
-  const [weekCount, setWeekCount] = useState(() => loadWeekCount());
-  const [lastWorkoutWeek, setLastWorkoutWeek] = useState(() => loadLastWorkoutWeek());
+  const [workoutHistory, setWorkoutHistory] = useState<WorkoutLog[]>(() => (
+    demo.enabled ? (demo.demoData?.workoutHistory ?? []) : loadWorkoutHistory()
+  ));
+  const [exerciseHistory, setExerciseHistory] = useState<ExerciseHistory>(() => (
+    demo.enabled ? (demo.demoData?.exerciseHistory ?? {}) : loadExerciseHistory()
+  ));
+  const [personalRecords, setPersonalRecords] = useState<PersonalRecords>(() => (
+    demo.enabled ? (demo.demoData?.personalRecords ?? {}) : loadPersonalRecords()
+  ));
+  const [weekCount, setWeekCount] = useState(() => (
+    demo.enabled ? (demo.demoData?.weekCount ?? 0) : loadWeekCount()
+  ));
+  const [lastWorkoutWeek, setLastWorkoutWeek] = useState(() => (
+    demo.enabled ? (demo.demoData?.lastWorkoutWeek ?? null) : loadLastWorkoutWeek()
+  ));
   const [showDeloadAlert, setShowDeloadAlert] = useState(false);
   const [newPR, setNewPR] = useState<{ name: string; weight: number } | null>(null);
+
+  useEffect(() => {
+    if (demo.enabled) {
+      const data = demo.demoData;
+      setWorkoutHistory(data?.workoutHistory ?? []);
+      setExerciseHistory(data?.exerciseHistory ?? {});
+      setPersonalRecords(data?.personalRecords ?? {});
+      setWeekCount(data?.weekCount ?? 0);
+      setLastWorkoutWeek(data?.lastWorkoutWeek ?? null);
+    } else {
+      setWorkoutHistory(loadWorkoutHistory());
+      setExerciseHistory(loadExerciseHistory());
+      setPersonalRecords(loadPersonalRecords());
+      setWeekCount(loadWeekCount());
+      setLastWorkoutWeek(loadLastWorkoutWeek());
+    }
+  }, [demo.enabled, demo.demoData]);
 
   const progress = useCallback(() => {
     const dayExercises = plan.dayExercises;
@@ -79,7 +108,11 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       if (e1rm > (personalRecords[name] || 0)) {
         const updated = { ...personalRecords, [name]: e1rm };
         setPersonalRecords(updated);
-        savePersonalRecords(updated);
+        if (demo.enabled) {
+          demo.updateDemoData(data => ({ ...data, personalRecords: updated }));
+        } else {
+          savePersonalRecords(updated);
+        }
         setNewPR({ name, weight: e1rm });
         setTimeout(() => setNewPR(null), 3000);
       }
@@ -94,7 +127,11 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
             estimated1RM: e1rm,
           }],
         };
-        saveExerciseHistory(updated);
+        if (demo.enabled) {
+          demo.updateDemoData(data => ({ ...data, exerciseHistory: updated }));
+        } else {
+          saveExerciseHistory(updated);
+        }
         return updated;
       });
     }
@@ -117,7 +154,7 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
         });
       }
     }
-  }, [state.completedSets, personalRecords, plan]);
+  }, [state.completedSets, personalRecords, plan, demo]);
 
   const endWorkout = useCallback((force = false) => {
     const pct = progress();
@@ -144,7 +181,11 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
 
     setWorkoutHistory(prev => {
       const updated = [...prev, newLog];
-      saveWorkoutHistory(updated);
+      if (demo.enabled) {
+        demo.updateDemoData(data => ({ ...data, workoutHistory: updated }));
+      } else {
+        saveWorkoutHistory(updated);
+      }
       return updated;
     });
 
@@ -154,15 +195,19 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       const newWeekCount = weekCount + 1;
       setWeekCount(newWeekCount);
       setLastWorkoutWeek(currentWeek);
-      saveWeekCount(newWeekCount);
-      saveLastWorkoutWeek(currentWeek);
+      if (demo.enabled) {
+        demo.updateDemoData(data => ({ ...data, weekCount: newWeekCount, lastWorkoutWeek: currentWeek }));
+      } else {
+        saveWeekCount(newWeekCount);
+        saveLastWorkoutWeek(currentWeek);
+      }
       if (newWeekCount > 0 && newWeekCount % 4 === 0) {
         setShowDeloadAlert(true);
       }
     }
 
     dispatch({ type: 'RESET' });
-  }, [progress, plan, state, weekCount, lastWorkoutWeek]);
+  }, [progress, plan, state, weekCount, lastWorkoutWeek, demo]);
 
   const resetWorkoutState = useCallback(() => {
     dispatch({ type: 'RESET' });
@@ -175,10 +220,14 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
   const dismissDeloadAlert = useCallback((reset: boolean) => {
     if (reset) {
       setWeekCount(0);
-      saveWeekCount(0);
+      if (demo.enabled) {
+        demo.updateDemoData(data => ({ ...data, weekCount: 0 }));
+      } else {
+        saveWeekCount(0);
+      }
     }
     setShowDeloadAlert(false);
-  }, []);
+  }, [demo]);
 
   const dismissPR = useCallback(() => setNewPR(null), []);
 

--- a/src/shared/demo/DemoModeContext.tsx
+++ b/src/shared/demo/DemoModeContext.tsx
@@ -1,0 +1,60 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { DemoData } from './demoData';
+import { ensureDemoData, loadDemoData, loadDemoMode, saveDemoData, saveDemoMode } from './demoData';
+
+interface DemoModeContextValue {
+  enabled: boolean;
+  demoData: DemoData | null;
+  setEnabled: (enabled: boolean) => void;
+  updateDemoData: (updater: (data: DemoData) => DemoData) => void;
+}
+
+const DemoModeContext = createContext<DemoModeContextValue | null>(null);
+
+export function DemoModeProvider({ children }: { children: ReactNode }) {
+  const [enabled, setEnabledState] = useState(() => loadDemoMode());
+  const [demoData, setDemoData] = useState<DemoData | null>(() => {
+    if (!loadDemoMode()) return null;
+    return loadDemoData() ?? ensureDemoData();
+  });
+
+  const setEnabled = useCallback((next: boolean) => {
+    saveDemoMode(next);
+    setEnabledState(next);
+    if (next) {
+      const data = loadDemoData() ?? ensureDemoData();
+      setDemoData(data);
+    } else {
+      setDemoData(null);
+    }
+  }, []);
+
+  const updateDemoData = useCallback((updater: (data: DemoData) => DemoData) => {
+    setDemoData(prev => {
+      const base = prev ?? ensureDemoData();
+      const updated = updater(base);
+      saveDemoData(updated);
+      return updated;
+    });
+  }, []);
+
+  const value = useMemo(() => ({
+    enabled,
+    demoData,
+    setEnabled,
+    updateDemoData,
+  }), [enabled, demoData, setEnabled, updateDemoData]);
+
+  return (
+    <DemoModeContext.Provider value={value}>
+      {children}
+    </DemoModeContext.Provider>
+  );
+}
+
+export function useDemoMode(): DemoModeContextValue {
+  const ctx = useContext(DemoModeContext);
+  if (!ctx) throw new Error('useDemoMode must be used within DemoModeProvider');
+  return ctx;
+}

--- a/src/shared/demo/demoData.ts
+++ b/src/shared/demo/demoData.ts
@@ -1,0 +1,212 @@
+import type { BodyMeasurement, ExerciseHistory, NutritionHistory, PersonalRecords, WorkoutLog } from '@/shared/types';
+import { calculate1RM, getTodayKey, getWeekNumber } from '@/shared/utils';
+
+export interface DemoData {
+  workoutHistory: WorkoutLog[];
+  exerciseHistory: ExerciseHistory;
+  personalRecords: PersonalRecords;
+  bodyMeasurements: BodyMeasurement[];
+  nutritionHistory: NutritionHistory;
+  weekCount: number;
+  lastWorkoutWeek: number | null;
+}
+
+const DEMO_MODE_KEY = 'ironDemoMode';
+const DEMO_DATA_KEY = 'ironDemoData';
+
+function lcg(seed: number): () => number {
+  let value = seed;
+  return () => {
+    value = (value * 48271) % 2147483647;
+    return value / 2147483647;
+  };
+}
+
+function randomBetween(rand: () => number, min: number, max: number): number {
+  return Math.round((min + (max - min) * rand()) * 10) / 10;
+}
+
+function dateKey(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function generateWorkoutHistory(): {
+  workoutHistory: WorkoutLog[];
+  exerciseHistory: ExerciseHistory;
+  personalRecords: PersonalRecords;
+} {
+  const rand = lcg(202410);
+  const today = new Date();
+  const start = addDays(today, -182);
+  const dayNames = ['Push', 'Pull', 'Legs', 'Upper'];
+  const exerciseMap: Record<string, string[]> = {
+    Push: ['Barbell Bench Press', 'Overhead Press', 'Incline Dumbbell Press'],
+    Pull: ['Deadlift', 'Barbell Row', 'Lat Pulldown'],
+    Legs: ['Squat', 'Romanian Deadlift', 'Leg Press'],
+    Upper: ['Barbell Bench Press', 'Barbell Row', 'Overhead Press'],
+  };
+
+  const workoutHistory: WorkoutLog[] = [];
+  const exerciseHistory: ExerciseHistory = {};
+  const personalRecords: PersonalRecords = {};
+
+  const totalDays = Math.floor((today.getTime() - start.getTime()) / 86400000);
+
+  for (let i = 0; i <= totalDays; i += 1) {
+    const current = addDays(start, i);
+    const key = dateKey(current);
+    const daysFromToday = Math.floor((today.getTime() - current.getTime()) / 86400000);
+    const dayOfWeek = current.getDay();
+    const isRecentStreak = daysFromToday <= 12;
+    const isWorkoutDay = isRecentStreak || [1, 3, 5, 6].includes(dayOfWeek);
+
+    if (!isWorkoutDay) continue;
+
+    const weekIndex = Math.floor(i / 7);
+    const dayName = dayNames[weekIndex % dayNames.length];
+    const exercises = exerciseMap[dayName] || [];
+    const sets = exercises.flatMap((name) => {
+      const base = name.includes('Deadlift') ? 140 : name.includes('Squat') ? 120 : name.includes('Bench') ? 95 : 70;
+      const progression = name.includes('Deadlift') || name.includes('Squat') ? 2.5 : 1.5;
+      const weightKg = Math.round(base + weekIndex * progression + randomBetween(rand, -2, 4));
+      const reps = name.includes('Deadlift') ? 5 : 8;
+      return Array.from({ length: 3 }).map((_, setIndex) => {
+        const rpe = (7 + Math.floor(rand() * 3)) as 7 | 8 | 9;
+        const entry = {
+          exerciseName: name,
+          weightKg: Math.max(40, weightKg + setIndex * 2.5),
+          reps,
+          setNumber: setIndex + 1,
+          rpe,
+        };
+
+        const estimated1RM = calculate1RM(entry.weightKg, entry.reps);
+        if (!exerciseHistory[name]) exerciseHistory[name] = [];
+        exerciseHistory[name].push({
+          date: key,
+          weightKg: entry.weightKg,
+          reps: entry.reps,
+          estimated1RM,
+        });
+        personalRecords[name] = Math.max(personalRecords[name] || 0, estimated1RM);
+        return entry;
+      });
+    });
+
+    const totalVolumeKg = sets.reduce((sum, set) => sum + set.weightKg * set.reps, 0);
+    const completionPercent = isRecentStreak ? 100 : Math.round(randomBetween(rand, 92, 100));
+
+    workoutHistory.push({
+      date: key,
+      dayName,
+      sets,
+      totalVolumeKg,
+      completionPercent,
+    });
+  }
+
+  return { workoutHistory, exerciseHistory, personalRecords };
+}
+
+function generateBodyMeasurements(): BodyMeasurement[] {
+  const rand = lcg(404);
+  const today = new Date();
+  const start = addDays(today, -182);
+  const measurements: BodyMeasurement[] = [];
+  const weeks = Math.floor((today.getTime() - start.getTime()) / 604800000);
+
+  for (let i = 0; i <= weeks; i += 1) {
+    const date = addDays(start, i * 7);
+    const weight = 92 - i * 0.25 + randomBetween(rand, -0.2, 0.2);
+    measurements.push({
+      date: dateKey(date),
+      weight: Math.round(weight * 10) / 10,
+      bodyFat: `${Math.max(10, 16 - i * 0.2).toFixed(1)}%`,
+      chest: `${100 + i * 0.2 + randomBetween(rand, -0.3, 0.3)}cm`,
+      waist: `${84 - i * 0.15 + randomBetween(rand, -0.3, 0.3)}cm`,
+      arms: `${36 + i * 0.1 + randomBetween(rand, -0.2, 0.2)}cm`,
+      thighs: `${58 + i * 0.15 + randomBetween(rand, -0.2, 0.2)}cm`,
+    });
+  }
+
+  return measurements;
+}
+
+function generateNutritionHistory(): NutritionHistory {
+  const rand = lcg(777);
+  const history: NutritionHistory = {};
+  for (let i = 0; i < 30; i += 1) {
+    const date = addDays(new Date(), -i);
+    const key = dateKey(date);
+    history[key] = {
+      water: Math.floor(randomBetween(rand, 8, 13)),
+      protein: Math.floor(randomBetween(rand, 140, 210)),
+      proteinLog: [
+        { name: 'Whey Shake', protein: 28, icon: '🥤', time: '08:15' },
+        { name: 'Chicken Breast', protein: 45, icon: '🍗', time: '12:30' },
+        { name: 'Greek Yogurt', protein: 20, icon: '🥣', time: '16:00' },
+      ],
+    };
+  }
+  return history;
+}
+
+export function generateDemoData(): DemoData {
+  const { workoutHistory, exerciseHistory, personalRecords } = generateWorkoutHistory();
+  const bodyMeasurements = generateBodyMeasurements();
+  const nutritionHistory = generateNutritionHistory();
+  const weekCount = 24;
+  const lastWorkoutWeek = getWeekNumber();
+
+  // ensure today's nutrition exists
+  const today = getTodayKey();
+  if (!nutritionHistory[today]) {
+    nutritionHistory[today] = { water: 10, protein: 180, proteinLog: [] };
+  }
+
+  return {
+    workoutHistory,
+    exerciseHistory,
+    personalRecords,
+    bodyMeasurements,
+    nutritionHistory,
+    weekCount,
+    lastWorkoutWeek,
+  };
+}
+
+export function loadDemoMode(): boolean {
+  return localStorage.getItem(DEMO_MODE_KEY) === 'true';
+}
+
+export function saveDemoMode(enabled: boolean): void {
+  localStorage.setItem(DEMO_MODE_KEY, enabled ? 'true' : 'false');
+}
+
+export function loadDemoData(): DemoData | null {
+  const raw = localStorage.getItem(DEMO_DATA_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as DemoData;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDemoData(data: DemoData): void {
+  localStorage.setItem(DEMO_DATA_KEY, JSON.stringify(data));
+}
+
+export function ensureDemoData(): DemoData {
+  const existing = loadDemoData();
+  if (existing) return existing;
+  const created = generateDemoData();
+  saveDemoData(created);
+  return created;
+}

--- a/src/shared/theme/styles.ts
+++ b/src/shared/theme/styles.ts
@@ -270,7 +270,7 @@ export const S: Record<string, CSSProperties> = {
   dayBtnActive: { border: `2px solid ${colors.primary}`, background: 'rgba(255,59,48,0.1)' },
 
   // Dashboard
-  sumGrid: { display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 10, marginBottom: spacing.lg },
+  sumGrid: { display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 10, marginBottom: spacing.lg },
   sumCard: { background: colors.surface, border: `1px solid ${colors.surfaceBorder}`, borderRadius: radii.xl, padding: spacing.xl - 6, textAlign: 'center' },
   sumLabel: { fontSize: '0.6rem', color: colors.textTertiary, marginBottom: 4, fontWeight: typography.weights.black, letterSpacing: '0.03em' },
   sumVal: { fontSize: typography.sizes['6xl'], fontWeight: typography.weights.black, color: colors.primary },
@@ -306,6 +306,13 @@ export const S: Record<string, CSSProperties> = {
   profileGrid: { display: 'grid', gridTemplateColumns: 'repeat(2,1fr)', gap: spacing.md, marginTop: spacing.md },
   profileItem: { display: 'flex', justifyContent: 'space-between', fontSize: typography.sizes.lg, padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.05)' },
   profileLabel: { color: colors.textTertiary },
+  demoRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: spacing.md, marginTop: spacing.lg, paddingTop: spacing.md, borderTop: `1px solid ${colors.surfaceBorder}` },
+  demoLabel: { fontSize: typography.sizes.md, fontWeight: typography.weights.bold },
+  demoHint: { fontSize: typography.sizes.sm, color: colors.textSecondary, marginTop: 4 },
+  demoToggle: { width: 56, height: 30, borderRadius: 999, border: `1px solid ${colors.surfaceBorder}`, background: colors.surfaceHover, padding: 2, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'flex-start', transition: 'all 0.2s ease' },
+  demoToggleOn: { background: colors.primary, border: `1px solid ${colors.primary}` },
+  demoKnob: { width: 24, height: 24, borderRadius: '50%', background: colors.text, transition: 'all 0.2s ease', boxShadow: '0 2px 6px rgba(0,0,0,0.3)' },
+  demoKnobOn: { background: '#fff', transform: 'translateX(26px)' },
 };
 
 export const globalCss = `


### PR DESCRIPTION
### Motivation
- Provide a developer-facing Demo Mode so the app can be populated with realistic lifter data for UI testing and developer motivation.
- Demo Mode should show ~6 months of workout history, PRs, streaks, nutrition and body measurements, and simulated completed programs so the dashboard and workout flows look like a serious lifter has been using the app.

### Description
- Add a seeded demo data generator and localStorage-backed demo store in `src/shared/demo/demoData.ts` that produces 6 months of workouts, exercise history, personal records, measurements, and nutrition history, and exposes `loadDemoMode`/`saveDemoMode` and demo data persistence helpers.
- Add a `DemoModeProvider` and `useDemoMode` hook in `src/shared/demo/DemoModeContext.tsx` to toggle demo mode and read/update demo data.
- Wire the provider into the app by wrapping the app tree with `DemoModeProvider` in `src/app/App.tsx` and exposing `useDemoMode` to the shell.
- Make workout, progress, and nutrition contexts demo-aware so they initialize from demo data when enabled and persist updates back to demo storage instead of the normal persistence layer; changes applied to `src/features/workout/WorkoutContext.tsx`, `src/features/progress/progress.context.tsx`, and `src/features/nutrition/nutrition.context.tsx`.
- Add a Dashboard toggle and small UI for Demo Mode plus a Programs summary card in `src/features/progress/Dashboard.tsx` and supporting styles in `src/shared/theme/styles.ts`.

### Testing
- Ran `npm install`; the environment produced warnings but completed (registry access in this environment may be limited). (succeeded with warnings)
- Attempted to start the dev server with `npm run dev` / `npx vite` but starting Vite failed due to missing local binary / registry access (environment restriction), so the application was not run in a browser here. (failed due to environment restrictions)
- No unit/integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986af55d0348330b562175b43a98181)