### PR TITLE
Fix off-by-one week tracking bug in date utilities

### DIFF
--- a/src/shared/utils/date.test.ts
+++ b/src/shared/utils/date.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getWeekNumber } from './date';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getWeekNumber', () => {
+  it('returns week 1 for Jan 1st', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'));
+
+    expect(getWeekNumber()).toBe(1);
+  });
+
+  it('increments only after 7 full days have elapsed', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-07T12:00:00Z'));
+    expect(getWeekNumber()).toBe(1);
+
+    vi.setSystemTime(new Date('2025-01-08T12:00:00Z'));
+    expect(getWeekNumber()).toBe(2);
+  });
+});

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -5,7 +5,7 @@ export function getTodayKey(): string {
 export function getWeekNumber(): number {
   const now = new Date();
   const yearStart = new Date(now.getFullYear(), 0, 1);
-  return Math.ceil((now.getTime() - yearStart.getTime()) / 604800000);
+  return Math.floor((now.getTime() - yearStart.getTime()) / 604800000) + 1;
 }
 
 export function getGreeting(): 'morning' | 'afternoon' | 'evening' {


### PR DESCRIPTION
### Motivation
- Week tracking used in workout/week-count logic could report the wrong week number (Jan 1 could be treated incorrectly and weekly rollover could occur too early). 

### Description
- Adjusted `getWeekNumber` in `src/shared/utils/date.ts` to use `Math.floor(...)/604800000 + 1` so weeks start at 1 on Jan 1 and advance only after a full 7-day interval. 
- Added `src/shared/utils/date.test.ts` with focused tests that assert Jan 1 is week 1 and that week increments only after 7 full days (Jan 7 -> still week 1, Jan 8 -> week 2).

### Testing
- Ran `npm test` and all tests passed (`9` test files, `107` tests total passed).
- Ran `npm run lint` which completed successfully with no warnings.
- Ran `npm run build` which completed successfully (build completed, with a size warning only).
- Note: running `npm test -- --runInBand` is not supported by the local `vitest` CLI and fails with an unknown option error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6b3a168883309137531c0f6d253b)