### PR TITLE
Reduce bundle size by lazy-loading homepage route

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { UserProfile } from '@/shared/types';
 import { Icon, ErrorBoundary } from '@/shared/components';
 import { S, globalCss } from '@/shared/theme/styles';
@@ -18,10 +18,11 @@ import { QuickWorkoutList } from '@/features/quick-workout/QuickWorkoutList';
 import { QuickWorkoutActive } from '@/features/quick-workout/QuickWorkoutActive';
 import { Profile } from '@/features/profile/Profile';
 import type { QuickTemplate } from '@/data/quick-templates';
-// @ts-expect-error — JSX homepage component without type declarations
-import Homepage from '@/ui/screens/Homepage';
 import { InstallBanner } from '@/features/pwa/InstallBanner';
 import { EntitlementProvider } from '@/features/entitlements/EntitlementContext';
+
+// @ts-expect-error — JSX homepage component without type declarations
+const Homepage = React.lazy(() => import('@/ui/screens/Homepage'));
 
 // Run migrations before first render
 runMigrations();
@@ -93,7 +94,11 @@ export default function App() {
 
   // Route: Homepage
   if (hash === '#/' || hash === '' || hash === '#') {
-    return <Homepage />;
+    return (
+      <Suspense fallback={<div style={{ minHeight: '100vh', background: '#0A0A0A' }} />}>
+        <Homepage />
+      </Suspense>
+    );
   }
 
   // Route: Main App (#/app)


### PR DESCRIPTION
### Motivation
- CI `build` job was failing because the generated JS bundle exceeded the 500KB gate (previous main chunk ~519.7 KB). 
- The intent is to remove non-critical code from the initial bundle so the CI size check passes without changing app behavior.

### Description
- Replaced the static `Homepage` import with `React.lazy(() => import('@/ui/screens/Homepage'))` and added `Suspense` to the homepage route in `src/app/App.tsx` to create a separate async chunk. 
- Kept a minimal fullscreen fallback while the homepage chunk is loading to preserve UX. 
- Added a `// @ts-expect-error` comment for the JSX-only `Homepage` import to avoid TypeScript noise.

### Testing
- `npm run build` succeeded and produced `dist/assets/index-*.js` at ~`489.11 kB` and a separate `Homepage` chunk at ~`31.82 kB`, bringing the main bundle under the CI threshold. 
- `npm run typecheck` completed without errors. 
- `npm run lint` completed without errors. 
- `npm test` passed (all unit tests ran successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6fabc89c83308ce885bf360d474c)