### PR TITLE
Fix demo-mode data, improve exercise filters & option contrast, and add "Create Your Own Workout"

### DIFF
--- a/src/data/exercises.ts
+++ b/src/data/exercises.ts
@@ -2144,9 +2144,24 @@ export function filterExercises(opts: {
   equipment?: Equipment | 'All';
   muscle?: MuscleGroup | 'All';
 }): Exercise[] {
+  const normalizeEquipment = (equipment: string): string => {
+    const value = equipment.toLowerCase();
+    if (value === 'none' || value === 'bodyweight') return 'bodyweight';
+    if (value === 'dumbbells') return 'dumbbell';
+    if (value === 'bar') return 'barbell';
+    if (value === 'band') return 'resistance band';
+    if (value === 'machine') return 'machine';
+    return value;
+  };
+
   let results = opts.search ? searchExercises(opts.search) : exercises;
   if (opts.equipment && opts.equipment !== 'All') {
-    results = results.filter(e => e.equipment === opts.equipment);
+    const target = normalizeEquipment(opts.equipment);
+    results = results.filter(e => {
+      const source = normalizeEquipment(e.equipment);
+      if (target === 'machine') return source.includes('machine');
+      return source === target;
+    });
   }
   if (opts.muscle && opts.muscle !== 'All') {
     results = results.filter(e => e.muscle === opts.muscle);

--- a/src/features/progress/Dashboard.tsx
+++ b/src/features/progress/Dashboard.tsx
@@ -5,7 +5,7 @@ import { useNutrition } from '@/features/nutrition/nutrition.context';
 import { useProgress } from './progress.context';
 import { MiniChart } from '@/shared/components';
 import { S } from '@/shared/theme/styles';
-import { getProteinGoal, WATER_GOAL, getLast7Days } from '@/shared/utils';
+import { WATER_GOAL } from '@/shared/utils';
 import { useTier } from '@/hooks/useTier';
 import { calculateFatigueScore } from '@/training/fatigue';
 import { generateWeeklyInsights } from '@/analytics/insights';
@@ -65,11 +65,8 @@ export function Dashboard({
 
   const [prFilter, setPrFilter] = useState('All');
 
-  const proteinGoal = getProteinGoal(profile.weight);
   const totalVol = workout.workoutHistory.reduce((a, w) => a + (w.totalVolumeKg || 0), 0);
   const volData = workout.workoutHistory.slice(-7).map(w => w.totalVolumeKg || 0);
-  const last7 = getLast7Days();
-  const proteinData = last7.map(d => nutrition.nutritionHistory[d]?.protein || 0);
   const weightData = progress.bodyMeasurements.slice(-10).map(m => parseFloat(String(m.weight)) || 0);
   const programsCompleted = Math.floor(workout.weekCount / 4);
 
@@ -250,18 +247,12 @@ export function Dashboard({
             <div style={S.miniProgress}><div style={{ ...S.miniProgressFill, width: `${(nutrition.todayWater / WATER_GOAL) * 100}%`, background: '#3B82F6' }} /></div>
             <button onClick={e => { e.stopPropagation(); nutrition.addWater(); }} style={S.nutritionCardBtn}>+ ADD</button>
           </div>
-          <div style={S.nutritionCard} onClick={onOpenNutrition}>
-            <div style={S.nutritionCardHeader}><span style={{ fontSize: '1.25rem' }}>{'\u{1F969}'}</span><span style={S.nutritionCardTitle}>Protein</span></div>
-            <div style={S.nutritionCardValue}>{nutrition.todayProtein}<span style={S.nutritionCardUnit}>g</span></div>
-            <div style={S.miniProgress}><div style={{ ...S.miniProgressFill, width: `${Math.min(100, (nutrition.todayProtein / proteinGoal) * 100)}%`, background: '#34C759' }} /></div>
-            <button onClick={e => { e.stopPropagation(); onOpenNutrition(); }} style={S.nutritionCardBtn}>+ LOG</button>
-          </div>
         </div>
       </div>
 
       <div style={S.chartBox}>
-        <h3 style={S.chartTitle}>{'\u{1F4CA}'} Protein (7 Days)</h3>
-        <MiniChart data={proteinData.length ? proteinData : [0]} color="#34C759" height={60} />
+        <h3 style={S.chartTitle}>{'\u{1F4CA}'} Hydration (7 Days)</h3>
+        <MiniChart data={Object.values(nutrition.nutritionHistory).slice(-7).map(d => d.water).length ? Object.values(nutrition.nutritionHistory).slice(-7).map(d => d.water) : [0]} color="#3B82F6" height={60} />
         <div style={S.chartLabels}><span>7 days ago</span><span>Today</span></div>
       </div>
 

--- a/src/features/training-plan/PlanContext.tsx
+++ b/src/features/training-plan/PlanContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useReducer, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import type { PlanExercise, WorkoutDay, UserProfile, Exercise } from '@/shared/types';
+import type { PlanExercise, WorkoutDay, UserProfile, Exercise, CustomWorkoutInput } from '@/shared/types';
 import { planReducer, createInitialPlan } from './plan.reducer';
 
 interface PlanContextValue {
@@ -15,6 +15,7 @@ interface PlanContextValue {
   addExercise: (exercise: Exercise) => void;
   removeExercise: (id: string) => void;
   swapExercise: (id: string, newExercise: Exercise) => void;
+  createCustomWorkout: (config: CustomWorkoutInput) => void;
 }
 
 const PlanContext = createContext<PlanContextValue | null>(null);
@@ -50,6 +51,10 @@ export function PlanProvider({ children, profile }: { children: ReactNode; profi
     dispatch({ type: 'SWAP_EXERCISE', id, newExercise });
   }, []);
 
+  const createCustomWorkout = useCallback((config: CustomWorkoutInput) => {
+    dispatch({ type: 'CREATE_CUSTOM_WORKOUT', config });
+  }, []);
+
   return (
     <PlanContext.Provider value={{
       days: state.days,
@@ -63,6 +68,7 @@ export function PlanProvider({ children, profile }: { children: ReactNode; profi
       addExercise,
       removeExercise,
       swapExercise,
+      createCustomWorkout,
     }}>
       {children}
     </PlanContext.Provider>

--- a/src/features/training-plan/plan.reducer.ts
+++ b/src/features/training-plan/plan.reducer.ts
@@ -1,4 +1,4 @@
-import type { PlanExercise, WorkoutDay, Exercise } from '@/shared/types';
+import type { PlanExercise, WorkoutDay, Exercise, CustomWorkoutInput } from '@/shared/types';
 import { isLowerBody } from '@/shared/types';
 import { findExerciseByName } from '@/data/exercises';
 import { workoutTemplates } from '@/data/templates';
@@ -16,7 +16,8 @@ export type PlanAction =
   | { type: 'UPDATE_EXERCISE'; id: string; patch: Partial<PlanExercise> }
   | { type: 'ADD_EXERCISE'; dayId: string; exercise: Exercise }
   | { type: 'REMOVE_EXERCISE'; id: string }
-  | { type: 'SWAP_EXERCISE'; id: string; newExercise: Exercise };
+  | { type: 'SWAP_EXERCISE'; id: string; newExercise: Exercise }
+  | { type: 'CREATE_CUSTOM_WORKOUT'; config: CustomWorkoutInput };
 
 function getWeightMultiplier(level: string): number {
   switch (level) {
@@ -65,6 +66,19 @@ export function createInitialPlan(profile: UserProfile, templateKey?: string): P
   return { days, exercises, dayIndex: 0 };
 }
 
+
+
+function createCustomWorkout(config: CustomWorkoutInput): PlanState {
+  const normalizedDays = Math.max(1, Math.min(7, Math.round(config.days)));
+  const dayNameBase = (config.name || 'Custom Workout').trim() || 'Custom Workout';
+  const days: WorkoutDay[] = Array.from({ length: normalizedDays }, (_, i) => ({
+    id: `custom-d${i}`,
+    name: normalizedDays === 1 ? dayNameBase : `${dayNameBase} ${i + 1}`,
+  }));
+
+  return { days, exercises: [], dayIndex: 0 };
+}
+
 export function planReducer(state: PlanState, action: PlanAction): PlanState {
   switch (action.type) {
     case 'INITIALIZE':
@@ -111,6 +125,9 @@ export function planReducer(state: PlanState, action: PlanAction): PlanState {
           pe.id === action.id ? { ...pe, exercise: action.newExercise } : pe
         ),
       };
+
+    case 'CREATE_CUSTOM_WORKOUT':
+      return createCustomWorkout(action.config);
 
     default:
       return state;

--- a/src/features/workout/WorkoutContext.tsx
+++ b/src/features/workout/WorkoutContext.tsx
@@ -342,7 +342,7 @@ export function WorkoutProvider({ children }: { children: ReactNode }) {
       }
 
       if (demo.enabled) {
-        demo.updateDemoData(data => ({ ...data, workoutHistory: updated }));
+        demo.updateDemoData(data => ({ ...data, workoutHistory: updated, globalPRs: updatedGlobal }));
       } else {
         saveWorkoutHistory(updated);
       }

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -187,9 +187,12 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
   const [showEndConfirm, setShowEndConfirm] = useState(false);
   const [showNutrition, setShowNutrition] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
+  const [showCustomWorkout, setShowCustomWorkout] = useState(false);
   const [showAddExercise, setShowAddExercise] = useState(false);
   const [showExerciseHistory, setShowExerciseHistory] = useState<string | null>(null);
   const [celebrate, setCelebrate] = useState(false);
+  const [customWorkoutName, setCustomWorkoutName] = useState('My Workout');
+  const [customWorkoutDays, setCustomWorkoutDays] = useState(4);
 
   // Exercise browser filter states (shared between Add and Swap modals)
   const [exSearch, setExSearch] = useState('');
@@ -311,6 +314,13 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
     setShowTemplates(false);
   };
 
+  const handleCreateCustomWorkout = () => {
+    plan.createCustomWorkout({ name: customWorkoutName, days: customWorkoutDays });
+    workout.resetWorkoutState();
+    setShowCustomWorkout(false);
+    setShowTemplates(false);
+  };
+
   const handleDayChange = (index: number) => {
     plan.setDayIndex(index);
     workout.resetWorkoutState();
@@ -333,11 +343,6 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
           <span style={S.nutritionIcon}>💧</span>
           <span style={S.nutritionValue}>{nutrition.todayWater}/{WATER_GOAL}</span>
           <button onClick={e => { e.stopPropagation(); nutrition.addWater(); }} style={S.addBtn}>+</button>
-        </div>
-        <div style={S.nutritionItem} onClick={() => setShowNutrition(true)}>
-          <span style={S.nutritionIcon}>🥩</span>
-          <span style={S.nutritionValue}>{nutrition.todayProtein}/{proteinGoal}g</span>
-          <button onClick={e => { e.stopPropagation(); setShowNutrition(true); }} style={S.addBtn}>+</button>
         </div>
       </div>
 
@@ -699,7 +704,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                 >
                   <option value="All">All Equipment</option>
                   {EQUIPMENT_TYPES.map(eq => (
-                    <option key={eq} value={eq}>{eq === 'None' ? 'Bodyweight' : eq}</option>
+                    <option key={eq} value={eq} style={ebStyles.option}>{eq === 'None' ? 'Bodyweight' : eq}</option>
                   ))}
                 </select>
                 <select
@@ -709,7 +714,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                 >
                   <option value="All">All Muscles</option>
                   {MUSCLE_GROUPS.map(m => (
-                    <option key={m} value={m}>{m}</option>
+                    <option key={m} value={m} style={ebStyles.option}>{m}</option>
                   ))}
                 </select>
               </div>
@@ -768,7 +773,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
               >
                 <option value="All">All Equipment</option>
                 {EQUIPMENT_TYPES.map(eq => (
-                  <option key={eq} value={eq}>{eq === 'None' ? 'Bodyweight' : eq}</option>
+                  <option key={eq} value={eq} style={ebStyles.option}>{eq === 'None' ? 'Bodyweight' : eq}</option>
                 ))}
               </select>
               <select
@@ -778,7 +783,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
               >
                 <option value="All">All Muscles</option>
                 {MUSCLE_GROUPS.map(m => (
-                  <option key={m} value={m}>{m}</option>
+                  <option key={m} value={m} style={ebStyles.option}>{m}</option>
                 ))}
               </select>
             </div>
@@ -832,7 +837,40 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                 </button>
               ))}
             </div>
+            <button onClick={() => setShowCustomWorkout(true)} style={templatesCustomStyles.launchBtn}>+ CREATE YOUR OWN WORKOUT</button>
             <button onClick={() => setShowTemplates(false)} style={S.templatesCancel}>CANCEL</button>
+          </div>
+        </div>
+      )}
+
+      {showCustomWorkout && (
+        <div style={S.overlay} onClick={() => setShowCustomWorkout(false)}>
+          <div style={templatesCustomStyles.modal} onClick={e => e.stopPropagation()}>
+            <h3 style={templatesCustomStyles.title}>Create Your Own Workout</h3>
+            <p style={templatesCustomStyles.sub}>Start from scratch with your own named split.</p>
+            <label style={templatesCustomStyles.label}>Workout Name</label>
+            <input
+              type="text"
+              value={customWorkoutName}
+              maxLength={32}
+              onChange={e => setCustomWorkoutName(e.target.value)}
+              placeholder="My Workout"
+              style={templatesCustomStyles.input}
+            />
+            <label style={templatesCustomStyles.label}>Training Days / Week</label>
+            <select
+              value={customWorkoutDays}
+              onChange={e => setCustomWorkoutDays(Number(e.target.value))}
+              style={templatesCustomStyles.select}
+            >
+              {[1, 2, 3, 4, 5, 6, 7].map(day => (
+                <option key={day} value={day} style={templatesCustomStyles.option}>{day} {day === 1 ? 'day' : 'days'}</option>
+              ))}
+            </select>
+            <div style={templatesCustomStyles.actions}>
+              <button onClick={() => setShowCustomWorkout(false)} style={templatesCustomStyles.cancel}>Cancel</button>
+              <button onClick={handleCreateCustomWorkout} style={templatesCustomStyles.create}>Create Workout</button>
+            </div>
           </div>
         </div>
       )}
@@ -980,5 +1018,61 @@ const ebStyles: Record<string, React.CSSProperties> = {
     fontWeight: typography.weights.bold,
     cursor: 'pointer',
     appearance: 'auto' as const,
+  },
+  option: {
+    background: '#111',
+    color: '#fff',
+  },
+};
+
+const templatesCustomStyles: Record<string, React.CSSProperties> = {
+  launchBtn: {
+    width: '100%',
+    borderRadius: radii.md,
+    border: `1px solid ${colors.primaryBorder}`,
+    background: 'rgba(255,59,48,0.08)',
+    color: colors.primary,
+    fontWeight: typography.weights.black,
+    fontSize: typography.sizes.sm,
+    padding: `${spacing.sm}px ${spacing.md}px`,
+    marginTop: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  modal: {
+    width: 'min(92vw, 420px)',
+    borderRadius: radii.xl,
+    background: colors.surface,
+    border: `1px solid ${colors.surfaceBorder}`,
+    padding: spacing.lg,
+  },
+  title: { color: colors.text, margin: 0, marginBottom: spacing.xs, fontSize: typography.sizes.xl },
+  sub: { color: colors.textSecondary, marginTop: 0, marginBottom: spacing.md, fontSize: typography.sizes.sm },
+  label: { display: 'block', color: colors.textSecondary, marginBottom: 6, fontSize: typography.sizes.xs, textTransform: 'uppercase', letterSpacing: '0.06em' },
+  input: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: `${spacing.sm}px ${spacing.md}px`,
+    borderRadius: radii.md,
+    border: `1px solid ${colors.surfaceBorder}`,
+    background: 'rgba(255,255,255,0.06)',
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  select: {
+    width: '100%',
+    padding: `${spacing.sm}px ${spacing.md}px`,
+    borderRadius: radii.md,
+    border: `1px solid ${colors.surfaceBorder}`,
+    background: colors.surface,
+    color: colors.text,
+    marginBottom: spacing.md,
+  },
+  option: { background: '#111', color: '#fff' },
+  actions: { display: 'flex', gap: spacing.sm, justifyContent: 'flex-end' },
+  cancel: {
+    borderRadius: radii.md, border: `1px solid ${colors.surfaceBorder}`, background: 'transparent', color: colors.textSecondary, padding: `${spacing.sm}px ${spacing.md}px`,
+  },
+  create: {
+    borderRadius: radii.md, border: 'none', background: colors.primary, color: '#fff', padding: `${spacing.sm}px ${spacing.md}px`, fontWeight: typography.weights.bold,
   },
 };

--- a/src/shared/demo/demoData.ts
+++ b/src/shared/demo/demoData.ts
@@ -294,7 +294,19 @@ export function saveDemoData(data: DemoData): void {
 
 export function ensureDemoData(): DemoData {
   const existing = loadDemoData();
-  if (existing) return existing;
+  if (
+    existing
+    && Array.isArray(existing.workoutHistory)
+    && existing.workoutHistory.length > 0
+    && existing.exerciseHistory
+    && existing.personalRecords
+    && existing.globalPRs
+    && Array.isArray(existing.bodyMeasurements)
+    && existing.nutritionHistory
+  ) {
+    return existing;
+  }
+
   const created = generateDemoData();
   saveDemoData(created);
   return created;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,7 +2,7 @@ export type { Exercise, MuscleGroup, Equipment, ExerciseType } from './exercise'
 export { MUSCLE_GROUPS, EQUIPMENT_TYPES, EXERCISE_TYPES, LOWER_BODY_MUSCLES, isLowerBody } from './exercise';
 
 export type {
-  RPEValue, PlanExercise, WorkoutDay, SetLog, WorkoutLog,
+  RPEValue, PlanExercise, WorkoutDay, CustomWorkoutInput, SetLog, WorkoutLog,
   ExerciseHistoryEntry, PersonalRecords, PersonalRecordsLegacy,
   ExercisePR, GlobalPRs, ExerciseHistory, CompletedSets,
 } from './workout';

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -20,6 +20,11 @@ export interface WorkoutDay {
   name: string;
 }
 
+export interface CustomWorkoutInput {
+  name: string;
+  days: number;
+}
+
 export interface SetLog {
   exerciseName: string;
   weightKg: number;


### PR DESCRIPTION
### Motivation
- Ensure demo mode reliably shows workout history, PRs, measurements and nutrition instead of appearing empty or only showing the exercise list.  
- Improve equipment filtering and dropdown readability so Add/Swap exercise flows actually match the catalog and are visible in dark UI.  
- Provide users a way to create named custom workouts (instead of being forced into pre-made templates) with a selectable number of days per week.  
- Reduce top-level emphasis on protein until a clearer nutrition UI is designed while keeping protein logging available in the detailed nutrition modal.

### Description
- Make demo data resilient by validating stored demo payloads in `ensureDemoData()` and regenerating seeded data when the saved demo object is incomplete, preventing missing records in demo mode (`src/shared/demo/demoData.ts`).  
- Persist updated global PRs back into demo-mode storage when logging workouts so demo mode reflects global PR updates (`src/features/workout/WorkoutContext.tsx`).  
- Normalize equipment labels in the exercise filter to handle mismatched/catalog aliases (`None`/`Bodyweight`, `Dumbbells`/`Dumbbell`, machine aliases, etc.), fixing Add/Swap filtering behavior (`src/data/exercises.ts`).  
- Improve select option contrast by styling `<option>` entries used in the exercise browser and custom-workout UI to avoid white-on-white selection issues (`src/features/workout/WorkoutView.tsx`).  
- Add "Create Your Own Workout" flow: new `CustomWorkoutInput` type, reducer action and helper to build a named split with 1–7 days, Plan context API to dispatch creation, and a templates modal launch button + modal UI to name the workout and pick days/week (`src/shared/types/workout.ts`, `src/shared/types/index.ts`, `src/features/training-plan/plan.reducer.ts`, `src/features/training-plan/PlanContext.tsx`, `src/features/workout/WorkoutView.tsx`).  
- Reduce top-level protein tiles/charts on the Dashboard and replace the 7-day protein chart with a hydration trend while leaving detailed protein logging intact in the nutrition modal (`src/features/progress/Dashboard.tsx`).

### Testing
- Ran unit tests with `npm run test -- --run` where all test suites passed (`111 tests, 10 files`).  
- Verified production build with `npm run build` completed successfully.  
- Performed a manual dev smoke run (`npm run dev`) and exercised the new templates -> create-your-own modal (screenshot captured during smoke run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7cc24c4883309647b5fe15fc9b87)