### PR TITLE
Refactor exercise filtering with curated filter options

### DIFF
--- a/src/data/exercises.test.ts
+++ b/src/data/exercises.test.ts
@@ -1,0 +1,156 @@
+import { filterExercises, exercises } from './exercises';
+
+describe('filterExercises', () => {
+  describe('equipment filter', () => {
+    it('filters Barbell exercises (includes Bar equipment)', () => {
+      const results = filterExercises({ equipment: 'Barbell' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(['Barbell', 'Bar']).toContain(ex.equipment);
+      });
+    });
+
+    it('filters Dumbbell exercises (includes Dumbbells equipment)', () => {
+      const results = filterExercises({ equipment: 'Dumbbell' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(['Dumbbell', 'Dumbbells']).toContain(ex.equipment);
+      });
+    });
+
+    it('filters Machine exercises (includes all machine variants)', () => {
+      const results = filterExercises({ equipment: 'Machine' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.equipment.toLowerCase()).toContain('machine');
+      });
+    });
+
+    it('filters Bodyweight exercises (includes None equipment)', () => {
+      const results = filterExercises({ equipment: 'Bodyweight' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(['Bodyweight', 'None']).toContain(ex.equipment);
+      });
+    });
+
+    it('filters Band exercises (includes Resistance Band)', () => {
+      const results = filterExercises({ equipment: 'Band' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(['Band', 'Resistance Band']).toContain(ex.equipment);
+      });
+    });
+
+    it('filters Cable exercises', () => {
+      const results = filterExercises({ equipment: 'Cable' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.equipment).toBe('Cable');
+      });
+    });
+
+    it('filters EZ Bar exercises', () => {
+      const results = filterExercises({ equipment: 'EZ Bar' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.equipment).toBe('EZ Bar');
+      });
+    });
+
+    it('returns all exercises when equipment is All', () => {
+      const results = filterExercises({ equipment: 'All' });
+      expect(results.length).toBe(exercises.length);
+    });
+  });
+
+  describe('muscle filter', () => {
+    it('filters Back exercises (includes Lats)', () => {
+      const results = filterExercises({ muscle: 'Back' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(['Back', 'Lats']).toContain(ex.muscle);
+      });
+      // Verify Lats are actually included
+      const latExercises = results.filter(ex => ex.muscle === 'Lats');
+      expect(latExercises.length).toBeGreaterThan(0);
+    });
+
+    it('filters Shoulders exercises (includes Rear Delts)', () => {
+      const results = filterExercises({ muscle: 'Shoulders' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(['Shoulders', 'Rear Delts']).toContain(ex.muscle);
+      });
+      // Verify Rear Delts are actually included
+      const rearDeltExercises = results.filter(ex => ex.muscle === 'Rear Delts');
+      expect(rearDeltExercises.length).toBeGreaterThan(0);
+    });
+
+    it('filters Chest exercises', () => {
+      const results = filterExercises({ muscle: 'Chest' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.muscle).toBe('Chest');
+      });
+    });
+
+    it('returns all exercises when muscle is All', () => {
+      const results = filterExercises({ muscle: 'All' });
+      expect(results.length).toBe(exercises.length);
+    });
+  });
+
+  describe('AND logic (equipment + muscle)', () => {
+    it('filters Cable + Back exercises', () => {
+      const results = filterExercises({ equipment: 'Cable', muscle: 'Back' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.equipment).toBe('Cable');
+        expect(['Back', 'Lats']).toContain(ex.muscle);
+      });
+    });
+
+    it('returns empty for impossible combination', () => {
+      const results = filterExercises({ equipment: 'EZ Bar', muscle: 'Calves' });
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('search + filter', () => {
+    it('combines search with equipment filter', () => {
+      const results = filterExercises({ search: 'bench', equipment: 'Barbell' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.name.toLowerCase()).toContain('bench');
+        expect(['Barbell', 'Bar']).toContain(ex.equipment);
+      });
+    });
+
+    it('combines search with muscle filter', () => {
+      const results = filterExercises({ search: 'curl', muscle: 'Biceps' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.name.toLowerCase()).toContain('curl');
+        expect(ex.muscle).toBe('Biceps');
+      });
+    });
+
+    it('combines search with both filters', () => {
+      const results = filterExercises({ search: 'press', equipment: 'Barbell', muscle: 'Chest' });
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach(ex => {
+        expect(ex.name.toLowerCase()).toContain('press');
+        expect(['Barbell', 'Bar']).toContain(ex.equipment);
+        expect(ex.muscle).toBe('Chest');
+      });
+    });
+  });
+
+  describe('no filters', () => {
+    it('returns all exercises when no filters applied', () => {
+      const results = filterExercises({});
+      expect(results.length).toBe(exercises.length);
+    });
+  });
+});

--- a/src/data/exercises.ts
+++ b/src/data/exercises.ts
@@ -1,4 +1,5 @@
-import type { Exercise, Equipment, MuscleGroup } from '@/shared/types';
+import type { Exercise, Equipment, MuscleGroup, EquipmentFilter, MuscleFilter } from '@/shared/types';
+import { MUSCLE_FILTER_MAP } from '@/shared/types';
 
 const baseExercises: Exercise[] = [
   // ── CHEST ──────────────────────────────────────────────────────────────
@@ -2055,8 +2056,8 @@ export function searchExercises(query: string): Exercise[] {
 /** Filter exercises by equipment and/or muscle, with optional search */
 export function filterExercises(opts: {
   search?: string;
-  equipment?: Equipment | 'All';
-  muscle?: MuscleGroup | 'All';
+  equipment?: EquipmentFilter;
+  muscle?: MuscleFilter;
 }): Exercise[] {
   const normalizeEquipment = (equipment: string): string => {
     const value = equipment.toLowerCase();
@@ -2078,7 +2079,10 @@ export function filterExercises(opts: {
     });
   }
   if (opts.muscle && opts.muscle !== 'All') {
-    results = results.filter(e => e.muscle === opts.muscle);
+    const matchGroups = MUSCLE_FILTER_MAP[opts.muscle];
+    if (matchGroups) {
+      results = results.filter(e => (matchGroups as readonly string[]).includes(e.muscle));
+    }
   }
   return results;
 }

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
-import type { PlanExercise, RPEValue, Exercise, Equipment, MuscleGroup } from '@/shared/types';
-import { EQUIPMENT_TYPES, MUSCLE_GROUPS } from '@/shared/types';
+import type { PlanExercise, RPEValue, Exercise, EquipmentFilter, MuscleFilter } from '@/shared/types';
+import { EQUIPMENT_FILTER_OPTIONS, MUSCLE_FILTER_OPTIONS, MUSCLE_FILTER_MAP } from '@/shared/types';
 import { usePlan } from '@/features/training-plan/PlanContext';
 import { useWorkout } from './WorkoutContext';
 import { useNutrition } from '@/features/nutrition/nutrition.context';
@@ -26,6 +26,15 @@ import type { WorkoutSummaryData } from './WorkoutSummary';
 
 
 type ExerciseDataModule = typeof import('@/data/exercises');
+
+/** Map a raw MuscleGroup (e.g. 'Lats') to its curated filter value (e.g. 'Back') */
+function toCuratedMuscle(raw: string): MuscleFilter {
+  for (const [filter, groups] of Object.entries(MUSCLE_FILTER_MAP)) {
+    if ((groups as readonly string[]).includes(raw)) return filter as MuscleFilter;
+  }
+  return 'All';
+}
+
 interface WorkoutViewProps {
   profile: UserProfile;
 }
@@ -198,8 +207,8 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
 
   // Exercise browser filter states (shared between Add and Swap modals)
   const [exSearch, setExSearch] = useState('');
-  const [exEquipment, setExEquipment] = useState<Equipment | 'All'>('All');
-  const [exMuscle, setExMuscle] = useState<MuscleGroup | 'All'>('All');
+  const [exEquipment, setExEquipment] = useState<EquipmentFilter>('All');
+  const [exMuscle, setExMuscle] = useState<MuscleFilter>('All');
 
   const [exerciseData, setExerciseData] = useState<ExerciseDataModule | null>(null);
 
@@ -692,10 +701,11 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
 
       {/* Swap exercise modal (Dual Filter) */}
       {showSwap && (() => {
+        const defaultMuscle = toCuratedMuscle(showSwap.exercise.muscle);
         const swapResults = exerciseData?.filterExercises({
           search: exSearch,
           equipment: exEquipment,
-          muscle: exMuscle === 'All' ? showSwap.exercise.muscle as MuscleGroup : exMuscle,
+          muscle: exMuscle === 'All' ? defaultMuscle : exMuscle,
         }).filter(ex => ex.id !== showSwap.exercise.id) ?? [];
         return (
           <div style={S.overlay} onClick={() => { setShowSwap(null); setExSearch(''); setExEquipment('All'); setExMuscle('All'); }}>
@@ -716,25 +726,32 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
               <div style={ebStyles.filterRow}>
                 <select
                   value={exEquipment}
-                  onChange={e => setExEquipment(e.target.value as Equipment | 'All')}
+                  onChange={e => setExEquipment(e.target.value as EquipmentFilter)}
                   style={ebStyles.select}
                 >
                   <option value="All">All Equipment</option>
-                  {EQUIPMENT_TYPES.map(eq => (
-                    <option key={eq} value={eq} style={ebStyles.option}>{eq === 'None' ? 'Bodyweight' : eq}</option>
+                  {EQUIPMENT_FILTER_OPTIONS.map(eq => (
+                    <option key={eq} value={eq} style={ebStyles.option}>{eq}</option>
                   ))}
                 </select>
                 <select
-                  value={exMuscle === 'All' ? showSwap.exercise.muscle : exMuscle}
-                  onChange={e => setExMuscle(e.target.value as MuscleGroup | 'All')}
+                  value={exMuscle === 'All' ? defaultMuscle : exMuscle}
+                  onChange={e => setExMuscle(e.target.value as MuscleFilter)}
                   style={ebStyles.select}
                 >
                   <option value="All">All Muscles</option>
-                  {MUSCLE_GROUPS.map(m => (
+                  {MUSCLE_FILTER_OPTIONS.map(m => (
                     <option key={m} value={m} style={ebStyles.option}>{m}</option>
                   ))}
                 </select>
               </div>
+
+              {/* Result count */}
+              <p style={ebStyles.resultCount}>
+                {swapResults.length > 0
+                  ? `${swapResults.length} exercise${swapResults.length !== 1 ? 's' : ''}`
+                  : 'No exercises match these filters'}
+              </p>
 
               <div style={S.swapList}>
                 {swapResults.map(ex => (
@@ -758,9 +775,6 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                     <button onClick={() => setShowHowTo(ex)} style={howToBtn}>?</button>
                   </div>
                 ))}
-                {swapResults.length === 0 && (
-                  <p style={{ color: colors.textTertiary, textAlign: 'center', padding: '1rem 0' }}>No exercises match filters</p>
-                )}
               </div>
             </div>
           </div>
@@ -787,25 +801,32 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
             <div style={ebStyles.filterRow}>
               <select
                 value={exEquipment}
-                onChange={e => setExEquipment(e.target.value as Equipment | 'All')}
+                onChange={e => setExEquipment(e.target.value as EquipmentFilter)}
                 style={ebStyles.select}
               >
                 <option value="All">All Equipment</option>
-                {EQUIPMENT_TYPES.map(eq => (
-                  <option key={eq} value={eq} style={ebStyles.option}>{eq === 'None' ? 'Bodyweight' : eq}</option>
+                {EQUIPMENT_FILTER_OPTIONS.map(eq => (
+                  <option key={eq} value={eq} style={ebStyles.option}>{eq}</option>
                 ))}
               </select>
               <select
                 value={exMuscle}
-                onChange={e => setExMuscle(e.target.value as MuscleGroup | 'All')}
+                onChange={e => setExMuscle(e.target.value as MuscleFilter)}
                 style={ebStyles.select}
               >
                 <option value="All">All Muscles</option>
-                {MUSCLE_GROUPS.map(m => (
+                {MUSCLE_FILTER_OPTIONS.map(m => (
                   <option key={m} value={m} style={ebStyles.option}>{m}</option>
                 ))}
               </select>
             </div>
+
+            {/* Result count */}
+            <p style={ebStyles.resultCount}>
+              {filteredExercises.length > 0
+                ? `${filteredExercises.length} exercise${filteredExercises.length !== 1 ? 's' : ''}`
+                : 'No exercises match these filters'}
+            </p>
 
             {/* Results */}
             <div style={S.addExList}>
@@ -831,9 +852,6 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                   <button onClick={() => setShowHowTo(ex)} style={howToBtn}>?</button>
                 </div>
               ))}
-              {filteredExercises.length === 0 && (
-                <p style={{ color: colors.textTertiary, textAlign: 'center', padding: '1rem 0' }}>No exercises match filters</p>
-              )}
             </div>
             <button onClick={() => { setShowAddExercise(false); setExSearch(''); setExEquipment('All'); setExMuscle('All'); }} style={S.addExCancel}>CANCEL</button>
           </div>
@@ -1043,6 +1061,13 @@ const ebStyles: Record<string, React.CSSProperties> = {
   option: {
     background: '#111',
     color: '#fff',
+  },
+  resultCount: {
+    color: colors.textSecondary,
+    fontSize: typography.sizes.sm,
+    textAlign: 'center' as const,
+    marginBottom: spacing.sm,
+    marginTop: 0,
   },
 };
 

--- a/src/shared/types/exercise.ts
+++ b/src/shared/types/exercise.ts
@@ -39,3 +39,31 @@ export const LOWER_BODY_MUSCLES: readonly MuscleGroup[] = [
 export function isLowerBody(muscle: MuscleGroup): boolean {
   return (LOWER_BODY_MUSCLES as readonly string[]).includes(muscle);
 }
+
+// ── Curated filter options (consolidated subset for UI dropdowns) ──
+
+export const EQUIPMENT_FILTER_OPTIONS = [
+  'Barbell', 'Dumbbell', 'Smith Machine', 'Cable',
+  'Machine', 'Bodyweight', 'EZ Bar', 'Kettlebell', 'Band',
+] as const;
+export type EquipmentFilter = typeof EQUIPMENT_FILTER_OPTIONS[number] | 'All';
+
+export const MUSCLE_FILTER_OPTIONS = [
+  'Chest', 'Back', 'Shoulders', 'Biceps', 'Triceps',
+  'Quads', 'Hamstrings', 'Glutes', 'Calves', 'Core',
+] as const;
+export type MuscleFilter = typeof MUSCLE_FILTER_OPTIONS[number] | 'All';
+
+/** Maps curated muscle filter → raw MuscleGroup values it covers */
+export const MUSCLE_FILTER_MAP: Record<typeof MUSCLE_FILTER_OPTIONS[number], readonly MuscleGroup[]> = {
+  Chest: ['Chest'],
+  Back: ['Back', 'Lats'],
+  Shoulders: ['Shoulders', 'Rear Delts'],
+  Biceps: ['Biceps'],
+  Triceps: ['Triceps'],
+  Quads: ['Quads'],
+  Hamstrings: ['Hamstrings'],
+  Glutes: ['Glutes'],
+  Calves: ['Calves'],
+  Core: ['Core'],
+};

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,5 +1,5 @@
-export type { Exercise, MuscleGroup, Equipment, ExerciseType } from './exercise';
-export { MUSCLE_GROUPS, EQUIPMENT_TYPES, EXERCISE_TYPES, LOWER_BODY_MUSCLES, isLowerBody } from './exercise';
+export type { Exercise, MuscleGroup, Equipment, ExerciseType, EquipmentFilter, MuscleFilter } from './exercise';
+export { MUSCLE_GROUPS, EQUIPMENT_TYPES, EXERCISE_TYPES, LOWER_BODY_MUSCLES, isLowerBody, EQUIPMENT_FILTER_OPTIONS, MUSCLE_FILTER_OPTIONS, MUSCLE_FILTER_MAP } from './exercise';
 
 export type {
   RPEValue, PlanExercise, WorkoutDay, CustomWorkoutInput, SetLog, WorkoutLog,


### PR DESCRIPTION
## Summary
This PR introduces a curated filtering system for exercises that consolidates raw equipment and muscle group values into user-friendly filter options. It separates the concept of "raw" exercise data (e.g., 'Lats', 'Bar') from "curated" filter UI options (e.g., 'Back', 'Barbell'), improving UX and maintainability.

## Key Changes

- **New filter type system**: Introduced `EquipmentFilter` and `MuscleFilter` types that represent curated UI options, distinct from raw `Equipment` and `MuscleGroup` values
  - `EQUIPMENT_FILTER_OPTIONS`: 9 curated equipment types (Barbell, Dumbbell, Machine, Cable, etc.)
  - `MUSCLE_FILTER_OPTIONS`: 10 curated muscle groups (Chest, Back, Shoulders, etc.)
  - `MUSCLE_FILTER_MAP`: Maps each curated filter to the raw muscle groups it encompasses (e.g., 'Back' → ['Back', 'Lats'])

- **Enhanced filtering logic**: Updated `filterExercises()` to handle equipment aliases and muscle group consolidation
  - Equipment filter now matches both exact values and common aliases (e.g., 'Barbell' matches 'Bar', 'Dumbbell' matches 'Dumbbells')
  - Muscle filter uses `MUSCLE_FILTER_MAP` to include related muscle groups (e.g., filtering 'Back' includes 'Lats')

- **Improved swap modal UX**: 
  - Added `toCuratedMuscle()` helper to map raw exercise muscle groups to curated filter values
  - Swap modal now defaults to the exercise's muscle group category instead of 'All'
  - Added result count display in both Add and Swap modals

- **Comprehensive test coverage**: Added 156 lines of tests covering:
  - Equipment filtering with aliases
  - Muscle filtering with grouping
  - AND logic (equipment + muscle combinations)
  - Search + filter combinations
  - Edge cases (empty results, no filters)

- **UI refinements**: Replaced hardcoded equipment/muscle lists with curated options, removed redundant "No exercises match filters" messages in favor of centralized result count display

## Implementation Details

The filtering system now uses a two-tier approach:
1. **Raw data layer**: Exercises store actual equipment/muscle values as-is
2. **Filter layer**: UI dropdowns use curated options that map to multiple raw values via `MUSCLE_FILTER_MAP` and equipment normalization

This allows exercises to use granular muscle group labels (Lats, Rear Delts) while presenting simplified filter options to users.

https://claude.ai/code/session_011rRTWvH6ac2BSw3RD9qLY2