### PR TITLE
Refactor custom workout creation to use builder-shaped payload

### DIFF
--- a/src/features/training-plan/plan.reducer.test.ts
+++ b/src/features/training-plan/plan.reducer.test.ts
@@ -218,6 +218,51 @@ describe('planReducer', () => {
     });
   });
 
+
+
+  describe('CREATE_CUSTOM_WORKOUT', () => {
+    it('builds a plan from provided program/day/exercise payload', () => {
+      const state = planReducer(initialState, {
+        type: 'CREATE_CUSTOM_WORKOUT',
+        config: {
+          programName: 'Strength Builder',
+          days: [
+            {
+              id: 'alpha',
+              name: 'Heavy Push',
+              exercises: [
+                { exerciseId: '1', sets: 5, reps: 5, weightKg: 100 },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(state.programName).toBe('Strength Builder');
+      expect(state.days).toEqual([{ id: 'alpha', name: 'Heavy Push' }]);
+      expect(state.exercises).toHaveLength(1);
+      expect(state.exercises[0].exercise.id).toBe('1');
+      expect(state.exercises[0].sets).toBe(5);
+      expect(state.exercises[0].reps).toBe(5);
+      expect(state.exercises[0].weightKg).toBe(100);
+    });
+
+    it('falls back to Day N names when provided names are blank', () => {
+      const state = planReducer(initialState, {
+        type: 'CREATE_CUSTOM_WORKOUT',
+        config: {
+          programName: 'Custom',
+          days: [
+            { id: 'one', name: '   ', exercises: [] },
+            { id: 'two', name: '', exercises: [] },
+          ],
+        },
+      });
+
+      expect(state.days.map(day => day.name)).toEqual(['Day 1', 'Day 2']);
+    });
+  });
+
   describe('SWAP_EXERCISE', () => {
     it('replaces the exercise object while keeping plan settings', () => {
       const target = initialState.exercises[0];

--- a/src/features/training-plan/plan.reducer.ts
+++ b/src/features/training-plan/plan.reducer.ts
@@ -1,6 +1,6 @@
-import type { PlanExercise, WorkoutDay, Exercise, CustomWorkoutInput } from '@/shared/types';
+import type { PlanExercise, WorkoutDay, Exercise, CustomWorkoutInput, CustomWorkoutDayInput } from '@/shared/types';
 import { isLowerBody } from '@/shared/types';
-import { findExerciseByName } from '@/data/exercises';
+import { exercises, findExerciseByName } from '@/data/exercises';
 import { workoutTemplates } from '@/data/templates';
 import type { UserProfile } from '@/shared/types';
 
@@ -8,6 +8,7 @@ export interface PlanState {
   days: WorkoutDay[];
   exercises: PlanExercise[];
   dayIndex: number;
+  programName?: string;
 }
 
 export type PlanAction =
@@ -63,20 +64,63 @@ export function createInitialPlan(profile: UserProfile, templateKey?: string): P
     });
   });
 
-  return { days, exercises, dayIndex: 0 };
+  return { days, exercises, dayIndex: 0, programName: template.name };
 }
 
 
+function toPositiveInt(value: number, fallback: number): number {
+  const normalized = Math.round(value);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : fallback;
+}
+
+function createExerciseFromInput(dayId: string, exerciseIndex: number, input: CustomWorkoutDayInput['exercises'][number]): PlanExercise | null {
+  const exercise = exercises.find(ex => ex.id === input.exerciseId) ?? findExerciseByName(input.exerciseId);
+  if (!exercise) return null;
+
+  const lower = isLowerBody(exercise.muscle);
+  const reps = toPositiveInt(input.reps, lower ? 8 : 10);
+
+  return {
+    id: `${dayId}-ex${exerciseIndex}`,
+    dayId,
+    exercise,
+    sets: toPositiveInt(input.sets, 3),
+    reps,
+    repsMin: reps,
+    repsMax: reps,
+    weightKg: Number.isFinite(input.weightKg) && input.weightKg >= 0 ? input.weightKg : 0,
+    restSeconds: 90,
+    progressionKg: 2.5,
+  };
+}
 
 function createCustomWorkout(config: CustomWorkoutInput): PlanState {
-  const normalizedDays = Math.max(1, Math.min(7, Math.round(config.days)));
-  const dayNameBase = (config.name || 'Custom Workout').trim() || 'Custom Workout';
-  const days: WorkoutDay[] = Array.from({ length: normalizedDays }, (_, i) => ({
-    id: `custom-d${i}`,
-    name: normalizedDays === 1 ? dayNameBase : `${dayNameBase} ${i + 1}`,
+  const programName = config.programName.trim() || 'Custom Workout';
+  const sourceDays = Array.isArray(config.days) ? config.days : [];
+  const fallbackDayId = 'custom-d0';
+
+  const days: WorkoutDay[] = (sourceDays.length > 0 ? sourceDays : [{ id: fallbackDayId, name: '', exercises: [] }]).map((day, index) => ({
+    id: day.id?.trim() || `custom-d${index}`,
+    name: day.name.trim() || `Day ${index + 1}`,
   }));
 
-  return { days, exercises: [], dayIndex: 0 };
+  const exercises: PlanExercise[] = [];
+  sourceDays.forEach((day, dayIndex) => {
+    const mappedDayId = days[dayIndex]?.id ?? `custom-d${dayIndex}`;
+    day.exercises.forEach((exerciseInput, exerciseIndex) => {
+      const mapped = createExerciseFromInput(mappedDayId, exerciseIndex, exerciseInput);
+      if (mapped) {
+        exercises.push(mapped);
+      }
+    });
+  });
+
+  return {
+    days,
+    exercises,
+    dayIndex: 0,
+    programName,
+  };
 }
 
 export function planReducer(state: PlanState, action: PlanAction): PlanState {

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -338,7 +338,14 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
   };
 
   const handleCreateCustomWorkout = () => {
-    plan.createCustomWorkout({ name: customWorkoutName, days: customWorkoutDays });
+    plan.createCustomWorkout({
+      programName: customWorkoutName,
+      days: Array.from({ length: customWorkoutDays }, (_, index) => ({
+        id: `custom-d${index}`,
+        name: `Day ${index + 1}`,
+        exercises: [],
+      })),
+    });
     workout.resetWorkoutState();
     setShowCustomWorkout(false);
     setShowTemplates(false);

--- a/src/shared/storage/storage.test.ts
+++ b/src/shared/storage/storage.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { loadTrainingPlan, StorageKeys } from './storage';
+
+describe('loadTrainingPlan', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('loads legacy plans without programName safely', () => {
+    localStorage.setItem(StorageKeys.TRAINING_PLAN, JSON.stringify({
+      days: [{ id: 'd1', name: 'Push' }],
+      exercises: [],
+      dayIndex: 0,
+    }));
+
+    const plan = loadTrainingPlan();
+    expect(plan).not.toBeNull();
+    expect(plan?.programName).toBeUndefined();
+    expect(plan?.days).toEqual([{ id: 'd1', name: 'Push' }]);
+  });
+
+  it('normalizes malformed legacy values to prevent crashes', () => {
+    localStorage.setItem(StorageKeys.TRAINING_PLAN, JSON.stringify({
+      days: [{ id: '', name: '   ' }, { id: 'd2', name: 'Legs' }],
+      exercises: [{ id: 'x', dayId: 'missing' }, { id: 'y', dayId: 'd2' }],
+      dayIndex: 999,
+      programName: '  Program  ',
+    }));
+
+    const plan = loadTrainingPlan();
+    expect(plan).not.toBeNull();
+    expect(plan?.days[0]).toEqual({ id: 'legacy-d0', name: 'Day 1' });
+    expect(plan?.dayIndex).toBe(1);
+    expect(plan?.exercises).toHaveLength(1);
+    expect(plan?.exercises[0].dayId).toBe('d2');
+  });
+});

--- a/src/shared/storage/storage.ts
+++ b/src/shared/storage/storage.ts
@@ -40,6 +40,7 @@ interface TrainingPlanState {
   days: WorkoutDay[];
   exercises: PlanExercise[];
   dayIndex: number;
+  programName?: string;
 }
 
 /** Safe JSON parse with Zod validation. Returns null on any failure. */
@@ -252,15 +253,47 @@ export function saveLastWorkoutWeek(week: number): void {
   localStorage.setItem(StorageKeys.LAST_WORKOUT_WEEK, week.toString());
 }
 
+function normalizeTrainingPlanState(parsed: unknown): TrainingPlanState | null {
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const candidate = parsed as Partial<TrainingPlanState>;
+  if (!Array.isArray(candidate.days) || !Array.isArray(candidate.exercises)) return null;
+
+  const days = candidate.days
+    .filter((day): day is WorkoutDay => Boolean(day) && typeof day.id === 'string' && typeof day.name === 'string')
+    .map((day, index) => ({
+      id: day.id.trim() || `legacy-d${index}`,
+      name: day.name.trim() || `Day ${index + 1}`,
+    }));
+
+  if (days.length === 0) return null;
+
+  const validDayIds = new Set(days.map(day => day.id));
+  const exercises = candidate.exercises
+    .filter((exercise): exercise is PlanExercise => Boolean(exercise) && typeof exercise.dayId === 'string')
+    .filter(exercise => validDayIds.has(exercise.dayId));
+
+  const safeDayIndex = typeof candidate.dayIndex === 'number'
+    ? Math.min(Math.max(Math.round(candidate.dayIndex), 0), days.length - 1)
+    : 0;
+
+  const programName = typeof candidate.programName === 'string' ? candidate.programName : undefined;
+
+  return {
+    days,
+    exercises,
+    dayIndex: safeDayIndex,
+    programName,
+  };
+}
+
 export function loadTrainingPlan(): TrainingPlanState | null {
   const raw = localStorage.getItem(StorageKeys.TRAINING_PLAN);
   if (!raw) return null;
 
   try {
-    const parsed = JSON.parse(raw) as Partial<TrainingPlanState>;
-    if (!Array.isArray(parsed.days) || !Array.isArray(parsed.exercises)) return null;
-    if (typeof parsed.dayIndex !== 'number') return null;
-    return parsed as TrainingPlanState;
+    const parsed = JSON.parse(raw);
+    return normalizeTrainingPlanState(parsed);
   } catch {
     return null;
   }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,7 +2,7 @@ export type { Exercise, MuscleGroup, Equipment, ExerciseType, EquipmentFilter, M
 export { MUSCLE_GROUPS, EQUIPMENT_TYPES, EXERCISE_TYPES, LOWER_BODY_MUSCLES, isLowerBody, EQUIPMENT_FILTER_OPTIONS, MUSCLE_FILTER_OPTIONS, MUSCLE_FILTER_MAP } from './exercise';
 
 export type {
-  RPEValue, PlanExercise, WorkoutDay, CustomWorkoutInput, SetLog, WorkoutLog,
+  RPEValue, PlanExercise, WorkoutDay, CustomWorkoutInput, CustomWorkoutDayInput, CustomWorkoutExerciseInput, SetLog, WorkoutLog,
   ExerciseHistoryEntry, PersonalRecords, PersonalRecordsLegacy,
   ExercisePR, GlobalPRs, ExerciseHistory, CompletedSets,
 } from './workout';

--- a/src/shared/types/workout.ts
+++ b/src/shared/types/workout.ts
@@ -20,9 +20,22 @@ export interface WorkoutDay {
   name: string;
 }
 
-export interface CustomWorkoutInput {
+export interface CustomWorkoutExerciseInput {
+  exerciseId: string;
+  sets: number;
+  reps: number;
+  weightKg: number;
+}
+
+export interface CustomWorkoutDayInput {
+  id: string;
   name: string;
-  days: number;
+  exercises: CustomWorkoutExerciseInput[];
+}
+
+export interface CustomWorkoutInput {
+  programName: string;
+  days: CustomWorkoutDayInput[];
 }
 
 export interface SetLog {


### PR DESCRIPTION
### Motivation
- Replace the minimal custom-workout input with a shape that can represent full builder state (program name, named days, and per-day exercises) so user-created plans can be persisted and reconstructed exactly.
- Ensure saved training-plan state remains compatible when the new shape is introduced to avoid crashes from legacy/malformed storage data.

### Description
- Replaced `CustomWorkoutInput` with `CustomWorkoutInput { programName, days: CustomWorkoutDayInput[] }` and added `CustomWorkoutDayInput` and `CustomWorkoutExerciseInput` types in `src/shared/types/workout.ts` and exported them via `src/shared/types/index.ts`.
- Rewrote `createCustomWorkout` in `src/features/training-plan/plan.reducer.ts` to use `programName`, honor provided day names (fallback to `Day N` only when blank), and build `days` and `exercises` from the provided payload; added helpers `toPositiveInt` and `createExerciseFromInput` and map exercise IDs to exercise objects.
- Updated the `WorkoutView` call site to send the new payload shape when creating a custom workout (`programName` + composed `days` array).
- Added a storage normalization helper in `src/shared/storage/storage.ts` for `loadTrainingPlan` that tolerates legacy saved plans by sanitizing day ids/names, clamping `dayIndex`, filtering exercises whose `dayId` no longer exists, and preserving optional `programName` when present.
- Added unit tests: extended `plan.reducer.test.ts` with `CREATE_CUSTOM_WORKOUT` tests and created `src/shared/storage/storage.test.ts` to validate legacy/malformed plan loading behavior.

### Testing
- Ran type checks with `npm run typecheck` and it completed successfully.
- Ran the focused test suite with `npm run test -- src/features/training-plan/plan.reducer.test.ts src/shared/storage/storage.test.ts` and all tests passed (`21 passed`).
- Ran lint with `npm run lint` and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f93b57e88330aa101e47b50a54d6)