### PR TITLE
Remove unused declarations from training-plan reducer

### DIFF
--- a/src/features/training-plan/plan.reducer.ts
+++ b/src/features/training-plan/plan.reducer.ts
@@ -3,11 +3,9 @@ import type {
   WorkoutDay,
   Exercise,
   CustomWorkoutInput,
-  CustomWorkoutDayInput,
-  CustomWorkoutExerciseInput,
 } from '@/shared/types';
 import { isLowerBody } from '@/shared/types';
-import { exercises, findExerciseByName } from '@/data/exercises';
+import { findExerciseByName } from '@/data/exercises';
 import { workoutTemplates } from '@/data/templates';
 import type { UserProfile } from '@/shared/types';
 
@@ -103,27 +101,6 @@ export function createInitialPlan(profile: UserProfile, templateKey?: string): P
 function toPositiveInt(value: number, fallback: number): number {
   const normalized = Math.round(value);
   return Number.isFinite(normalized) && normalized > 0 ? normalized : fallback;
-}
-
-function createExerciseFromInput(dayId: string, exerciseIndex: number, input: CustomWorkoutExerciseInput): PlanExercise | null {
-  const exercise = exercises.find(ex => ex.id === input.exerciseId) ?? findExerciseByName(input.exerciseId);
-  if (!exercise) return null;
-
-  const lower = isLowerBody(exercise.muscle);
-  const reps = toPositiveInt(input.reps, lower ? 8 : 10);
-
-  return {
-    id: `${dayId}-ex${exerciseIndex}`,
-    dayId,
-    exercise,
-    sets: toPositiveInt(input.sets, 3),
-    reps,
-    repsMin: reps,
-    repsMax: reps,
-    weightKg: Number.isFinite(input.weightKg) && input.weightKg >= 0 ? input.weightKg : 0,
-    restSeconds: 90,
-    progressionKg: 2.5,
-  };
 }
 
 function createCustomWorkout(config: CustomWorkoutInput): PlanState {


### PR DESCRIPTION
### Motivation
- Remove unused type imports and a helper that caused `@typescript-eslint/no-unused-vars` lint errors in `plan.reducer.ts`.

### Description
- Deleted unused `CustomWorkoutDayInput` and `CustomWorkoutExerciseInput` type imports, removed the unused `createExerciseFromInput` helper, and cleaned up the now-unused `exercises` import from `@/data/exercises`.

### Testing
- Ran `npx eslint src/ --max-warnings 0` and it completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699403f950348330810d489108a49a8a)