### PR TITLE
Refactor custom workout builder to use unified draft state

### DIFF
--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -39,33 +39,17 @@ interface WorkoutViewProps {
   profile: UserProfile;
 }
 
-interface BuilderDraftExercise {
+interface CustomWorkoutDraftExercise {
   exercise: Exercise;
   sets: number;
   reps: number;
   weightKg: number;
 }
 
-interface BuilderDraftDay {
-  id: string;
-  name: string;
-  exercises: BuilderDraftExercise[];
-}
-
-function createBuilderDraftDays(dayCount: number, workoutName: string): BuilderDraftDay[] {
-  const normalizedDays = Math.max(1, Math.min(7, Math.round(dayCount)));
-  const dayNameBase = (workoutName || 'Custom Workout').trim() || 'Custom Workout';
-
-  return Array.from({ length: normalizedDays }, (_, i) => ({
-    id: `builder-day-${i}`,
-    name: normalizedDays === 1 ? dayNameBase : `${dayNameBase} ${i + 1}`,
-    exercises: [],
-  }));
-}
 interface CustomWorkoutDraftDay {
   id: string;
   name: string;
-  exercises: Exercise[];
+  exercises: CustomWorkoutDraftExercise[];
 }
 
 interface CustomWorkoutDraft {
@@ -241,14 +225,9 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
   const [showNutrition, setShowNutrition] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
   const [showCustomWorkout, setShowCustomWorkout] = useState(false);
-  const [showBuilderExerciseBrowser, setShowBuilderExerciseBrowser] = useState(false);
   const [showAddExercise, setShowAddExercise] = useState(false);
   const [showExerciseHistory, setShowExerciseHistory] = useState<string | null>(null);
   const [celebrate, setCelebrate] = useState(false);
-  const [customWorkoutName, setCustomWorkoutName] = useState('My Workout');
-  const [customWorkoutDays, setCustomWorkoutDays] = useState(4);
-  const [builderDraftDays, setBuilderDraftDays] = useState<BuilderDraftDay[]>(() => createBuilderDraftDays(4, 'My Workout'));
-  const [builderActiveDayId, setBuilderActiveDayId] = useState<string | null>(null);
   const [customBuilderStep, setCustomBuilderStep] = useState<1 | 2 | 3 | 4>(1);
   const [customWorkoutDraft, setCustomWorkoutDraft] = useState<CustomWorkoutDraft>(EMPTY_CUSTOM_WORKOUT_DRAFT);
   const [selectedBuilderDayId, setSelectedBuilderDayId] = useState<string | null>(null);
@@ -261,13 +240,13 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
   const [exerciseData, setExerciseData] = useState<ExerciseDataModule | null>(null);
 
   useEffect(() => {
-    if (!showAddExercise && !showSwap && !showExerciseHistory && !showBuilderExerciseBrowser) return;
+    if (!showAddExercise && !showSwap && !showExerciseHistory) return;
     let mounted = true;
     import('@/data/exercises').then((mod) => {
       if (mounted) setExerciseData(mod);
     });
     return () => { mounted = false; };
-  }, [showAddExercise, showSwap, showExerciseHistory, showBuilderExerciseBrowser]);
+  }, [showAddExercise, showSwap, showExerciseHistory]);
 
   // Filtered exercise list for dual-filter
   const filteredExercises = useMemo(() => {
@@ -379,83 +358,42 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
     }
   };
 
-  const updateBuilderExerciseField = (dayId: string, exerciseIndex: number, patch: Partial<BuilderDraftExercise>) => {
-    setBuilderDraftDays(prev => prev.map(day => {
-      if (day.id !== dayId) return day;
-      return {
-        ...day,
-        exercises: day.exercises.map((draftExercise, index) =>
-          index === exerciseIndex ? { ...draftExercise, ...patch } : draftExercise,
-        ),
-      };
-    }));
-  };
-
-  const removeBuilderExercise = (dayId: string, exerciseIndex: number) => {
-    setBuilderDraftDays(prev => prev.map(day => {
-      if (day.id !== dayId) return day;
-      return {
-        ...day,
-        exercises: day.exercises.filter((_, index) => index !== exerciseIndex),
-      };
-    }));
-  };
-
-  const addBuilderExercise = (exercise: Exercise) => {
-    if (!builderActiveDayId) return;
-
-    setBuilderDraftDays(prev => prev.map(day => {
-      if (day.id !== builderActiveDayId) return day;
-      const lower = isLowerBody(exercise.muscle);
-      return {
-        ...day,
-        exercises: [...day.exercises, {
-          exercise,
-          sets: 3,
-          reps: lower ? 8 : 10,
-          weightKg: exercise.isBodyweight ? 0 : 20,
-        }],
-      };
-    }));
-
-    setShowBuilderExerciseBrowser(false);
-    setBuilderActiveDayId(null);
-    setExSearch('');
-    setExEquipment('All');
-    setExMuscle('All');
-  };
-
   const handleApplyTemplate = (key: string) => {
     plan.initialize(profile, key);
     workout.resetWorkoutState();
     setShowTemplates(false);
   };
 
-  const handleLaunchCustomWorkoutBuilder = () => {
-    setBuilderDraftDays(createBuilderDraftDays(customWorkoutDays, customWorkoutName));
-    setBuilderActiveDayId(null);
-    setShowBuilderExerciseBrowser(false);
-    setShowCustomWorkout(true);
+  const updateDraftExerciseField = (dayId: string, exerciseIndex: number, patch: Partial<CustomWorkoutDraftExercise>) => {
+    setCustomWorkoutDraft(prev => ({
+      ...prev,
+      days: prev.days.map(day => day.id === dayId
+        ? { ...day, exercises: day.exercises.map((ex, i) => i === exerciseIndex ? { ...ex, ...patch } : ex) }
+        : day),
+    }));
   };
 
-  const handleCustomWorkoutDaysChange = (days: number) => {
-    setCustomWorkoutDays(days);
-    setBuilderDraftDays(prev => {
-      const nextBase = createBuilderDraftDays(days, customWorkoutName);
-      return nextBase.map((nextDay, index) => ({
-        ...nextDay,
-        name: prev[index]?.name ?? nextDay.name,
-        exercises: prev[index]?.exercises ?? [],
-      }));
-    });
+  const removeDraftExercise = (dayId: string, exerciseIndex: number) => {
+    setCustomWorkoutDraft(prev => ({
+      ...prev,
+      days: prev.days.map(day => day.id === dayId
+        ? { ...day, exercises: day.exercises.filter((_, i) => i !== exerciseIndex) }
+        : day),
+    }));
   };
 
-  const handleCustomWorkoutNameChange = (name: string) => {
-    setCustomWorkoutName(name);
-    setBuilderDraftDays(prev => prev.map((day, index) => ({
-      ...day,
-      name: name.trim() ? `${name.trim()} ${index + 1}` : day.name,
-    })));
+  const reorderDraftExercise = (dayId: string, fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return;
+    setCustomWorkoutDraft(prev => ({
+      ...prev,
+      days: prev.days.map(day => {
+        if (day.id !== dayId) return day;
+        const exercises = [...day.exercises];
+        const [moved] = exercises.splice(fromIndex, 1);
+        exercises.splice(toIndex, 0, moved);
+        return { ...day, exercises };
+      }),
+    }));
   };
 
   const resetCustomWorkoutBuilder = () => {
@@ -483,14 +421,19 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
     plan.createCustomWorkout({
       name: programName,
       days: customWorkoutDraft.daysPerWeek,
-      dayConfigs: customWorkoutDraft.days.map((day, index) => ({
+      dayExercises: customWorkoutDraft.days.map((day, index) => ({
         name: day.name.trim() || `Day ${index + 1}`,
-        exercises: day.exercises,
+        exercises: day.exercises.map(de => ({
+          exercise: de.exercise,
+          sets: de.sets,
+          reps: de.reps,
+          weightKg: de.weightKg,
+        })),
       })),
     });
     workout.resetWorkoutState();
-    setShowBuilderExerciseBrowser(false);
-    setBuilderActiveDayId(null);
+    setShowAddExercise(false);
+    setSelectedBuilderDayId(null);
     setShowCustomWorkout(false);
     setShowTemplates(false);
     resetCustomWorkoutBuilder();
@@ -1009,10 +952,16 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                   <button
                     onClick={() => {
                       if (selectedBuilderDayId) {
+                        const lower = isLowerBody(ex.muscle);
                         setCustomWorkoutDraft(prev => ({
                           ...prev,
                           days: prev.days.map(day => day.id === selectedBuilderDayId
-                            ? { ...day, exercises: [...day.exercises, ex] }
+                            ? { ...day, exercises: [...day.exercises, {
+                                exercise: ex,
+                                sets: 3,
+                                reps: lower ? 8 : 10,
+                                weightKg: ex.isBodyweight ? 0 : 20,
+                              }] }
                             : day),
                         }));
                       } else {
@@ -1060,7 +1009,6 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                 </button>
               ))}
             </div>
-            <button onClick={handleLaunchCustomWorkoutBuilder} style={templatesCustomStyles.launchBtn}>+ CREATE YOUR OWN WORKOUT</button>
             <button onClick={() => { resetCustomWorkoutBuilder(); setShowCustomWorkout(true); }} style={templatesCustomStyles.launchBtn}>+ CREATE YOUR OWN WORKOUT</button>
             <button onClick={() => setShowTemplates(false)} style={S.templatesCancel}>CANCEL</button>
           </div>
@@ -1076,93 +1024,13 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
           }}
         >
           <div style={templatesCustomStyles.modal} onClick={e => e.stopPropagation()}>
-            <h3 style={templatesCustomStyles.title}>Create Your Own Workout</h3>
-            <p style={templatesCustomStyles.sub}>Start from scratch with your own named split.</p>
-            <label style={templatesCustomStyles.label}>Workout Name</label>
-            <input
-              type="text"
-              value={customWorkoutName}
-              maxLength={32}
-              onChange={e => handleCustomWorkoutNameChange(e.target.value)}
-              placeholder="My Workout"
-              style={templatesCustomStyles.input}
-            />
-            <label style={templatesCustomStyles.label}>Training Days / Week</label>
-            <select
-              value={customWorkoutDays}
-              onChange={e => handleCustomWorkoutDaysChange(Number(e.target.value))}
-              style={templatesCustomStyles.select}
-            >
-              {[1, 2, 3, 4, 5, 6, 7].map(day => (
-                <option key={day} value={day} style={templatesCustomStyles.option}>{day} {day === 1 ? 'day' : 'days'}</option>
-              ))}
-            </select>
-
-            <div style={templatesCustomStyles.dayCards}>
-              {builderDraftDays.map(day => (
-                <div key={day.id} style={templatesCustomStyles.dayCard}>
-                  <div style={templatesCustomStyles.dayHeader}>
-                    <div style={templatesCustomStyles.dayName}>{day.name}</div>
-                    <button
-                      onClick={() => {
-                        setBuilderActiveDayId(day.id);
-                        setShowBuilderExerciseBrowser(true);
-                      }}
-                      style={templatesCustomStyles.dayAddBtn}
-                    >
-                      + Add exercise
-                    </button>
-                  </div>
-                  {day.exercises.length === 0 ? (
-                    <div style={templatesCustomStyles.dayEmpty}>No exercises added yet.</div>
-                  ) : (
-                    <div style={templatesCustomStyles.dayExerciseList}>
-                      {day.exercises.map((draftExercise, exerciseIndex) => (
-                        <div key={`${draftExercise.exercise.id}-${exerciseIndex}`} style={templatesCustomStyles.dayExerciseRow}>
-                          <button onClick={() => removeBuilderExercise(day.id, exerciseIndex)} style={templatesCustomStyles.rowRemoveBtn}>×</button>
-                          <div style={templatesCustomStyles.rowMeta}>
-                            <div style={templatesCustomStyles.rowName}>{draftExercise.exercise.name}</div>
-                            <div style={templatesCustomStyles.rowSub}>{draftExercise.exercise.muscle}</div>
-                          </div>
-                          <input
-                            type="number"
-                            min={0}
-                            step={0.5}
-                            value={draftExercise.weightKg}
-                            onChange={e => updateBuilderExerciseField(day.id, exerciseIndex, { weightKg: Number(e.target.value) })}
-                            style={templatesCustomStyles.rowInput}
-                            aria-label="Weight (kg)"
-                          />
-                          <input
-                            type="number"
-                            min={1}
-                            step={1}
-                            value={draftExercise.reps}
-                            onChange={e => updateBuilderExerciseField(day.id, exerciseIndex, { reps: Number(e.target.value) })}
-                            style={templatesCustomStyles.rowInput}
-                            aria-label="Reps"
-                          />
-                          <input
-                            type="number"
-                            min={1}
-                            step={1}
-                            value={draftExercise.sets}
-                            onChange={e => updateBuilderExerciseField(day.id, exerciseIndex, { sets: Number(e.target.value) })}
-                            style={templatesCustomStyles.rowInput}
-                            aria-label="Sets"
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
             <div style={templatesCustomStyles.stepBadge}>Step {customBuilderStep} of 4</div>
 
             {customBuilderStep === 1 && (
               <>
                 <h3 style={templatesCustomStyles.title}>Name your program</h3>
+                <p style={templatesCustomStyles.sub}>Give your training program a name.</p>
+                <label style={templatesCustomStyles.label}>Program Name</label>
                 <input
                   type="text"
                   value={customWorkoutDraft.name}
@@ -1177,6 +1045,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
             {customBuilderStep === 2 && (
               <>
                 <h3 style={templatesCustomStyles.title}>How many days per week?</h3>
+                <p style={templatesCustomStyles.sub}>Select your training frequency.</p>
                 <select
                   value={customWorkoutDraft.daysPerWeek}
                   onChange={e => handleCustomWorkoutDraftDaysChange(Number(e.target.value))}
@@ -1199,14 +1068,16 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
 
             {customBuilderStep === 3 && (
               <>
-                <h3 style={templatesCustomStyles.title}>Build each day</h3>
+                <h3 style={templatesCustomStyles.title}>Name each day &amp; add exercises</h3>
+                <p style={templatesCustomStyles.sub}>Customize day names and pick exercises.</p>
                 <div style={templatesCustomStyles.dayCardsList}>
-                  {customWorkoutDraft.days.map((day, index) => (
+                  {customWorkoutDraft.days.map((day, dayIndex) => (
                     <div key={day.id} style={templatesCustomStyles.dayCard}>
                       <input
                         type="text"
                         value={day.name}
-                        placeholder={`Day ${index + 1}`}
+                        maxLength={32}
+                        placeholder={`Day ${dayIndex + 1}`}
                         onChange={e => setCustomWorkoutDraft(prev => ({
                           ...prev,
                           days: prev.days.map(d => d.id === day.id ? { ...d, name: e.target.value } : d),
@@ -1216,10 +1087,79 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                       <div style={templatesCustomStyles.dayExerciseList}>
                         {day.exercises.length === 0 ? (
                           <div style={templatesCustomStyles.emptyExerciseText}>No exercises added yet.</div>
-                        ) : day.exercises.map(ex => (
-                          <div key={`${day.id}-${ex.id}-${ex.name}`} style={templatesCustomStyles.exerciseItem}>{ex.name}</div>
+                        ) : day.exercises.map((de, exerciseIndex) => (
+                          <div key={`${day.id}-${de.exercise.id}-${exerciseIndex}`} style={templatesCustomStyles.dayExerciseRow}>
+                            <div style={templatesCustomStyles.rowOrderBtns}>
+                              <button
+                                onClick={() => reorderDraftExercise(day.id, exerciseIndex, exerciseIndex - 1)}
+                                disabled={exerciseIndex === 0}
+                                style={{ ...templatesCustomStyles.rowOrderBtn, ...(exerciseIndex === 0 ? templatesCustomStyles.rowOrderBtnDisabled : {}) }}
+                                aria-label={`Move ${de.exercise.name} up`}
+                              >
+                                {'\u2191'}
+                              </button>
+                              <button
+                                onClick={() => reorderDraftExercise(day.id, exerciseIndex, exerciseIndex + 1)}
+                                disabled={exerciseIndex === day.exercises.length - 1}
+                                style={{ ...templatesCustomStyles.rowOrderBtn, ...(exerciseIndex === day.exercises.length - 1 ? templatesCustomStyles.rowOrderBtnDisabled : {}) }}
+                                aria-label={`Move ${de.exercise.name} down`}
+                              >
+                                {'\u2193'}
+                              </button>
+                            </div>
+                            <div style={templatesCustomStyles.rowMeta}>
+                              <div style={templatesCustomStyles.rowName}>{de.exercise.name}</div>
+                              <div style={templatesCustomStyles.rowSub}>{de.exercise.muscle}</div>
+                            </div>
+                            <input
+                              type="number"
+                              min={1}
+                              step={1}
+                              value={de.sets}
+                              onChange={e => updateDraftExerciseField(day.id, exerciseIndex, { sets: Math.max(1, Number(e.target.value)) })}
+                              style={templatesCustomStyles.rowInput}
+                              aria-label="Sets"
+                              title="Sets"
+                            />
+                            <input
+                              type="number"
+                              min={1}
+                              step={1}
+                              value={de.reps}
+                              onChange={e => updateDraftExerciseField(day.id, exerciseIndex, { reps: Math.max(1, Number(e.target.value)) })}
+                              style={templatesCustomStyles.rowInput}
+                              aria-label="Reps"
+                              title="Reps"
+                            />
+                            <input
+                              type="number"
+                              min={0}
+                              step={2.5}
+                              value={de.weightKg}
+                              onChange={e => updateDraftExerciseField(day.id, exerciseIndex, { weightKg: Math.max(0, Number(e.target.value)) })}
+                              style={templatesCustomStyles.rowInput}
+                              aria-label="Weight (kg)"
+                              title="Weight (kg)"
+                            />
+                            <button
+                              onClick={() => removeDraftExercise(day.id, exerciseIndex)}
+                              style={templatesCustomStyles.rowRemoveBtn}
+                              aria-label={`Remove ${de.exercise.name}`}
+                            >
+                              {'\u00D7'}
+                            </button>
+                          </div>
                         ))}
                       </div>
+                      {day.exercises.length > 0 && (
+                        <div style={templatesCustomStyles.rowHeaderLabels}>
+                          <span style={templatesCustomStyles.rowHeaderSpacer} />
+                          <span style={templatesCustomStyles.rowHeaderLabel}>Sets</span>
+                          <span style={templatesCustomStyles.rowHeaderLabel}>Reps</span>
+                          <span style={templatesCustomStyles.rowHeaderLabel}>kg</span>
+                          <span style={templatesCustomStyles.rowHeaderRemoveSpacer} />
+                        </div>
+                      )}
                       <button
                         onClick={() => {
                           setSelectedBuilderDayId(day.id);
@@ -1238,17 +1178,21 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
             {customBuilderStep === 4 && (
               <>
                 <h3 style={templatesCustomStyles.title}>Review your program</h3>
+                <p style={templatesCustomStyles.sub}>Confirm everything looks good before saving.</p>
                 <div style={templatesCustomStyles.summaryHeader}>{customWorkoutDraft.name.trim() || 'Custom Program'}</div>
+                <div style={templatesCustomStyles.summarySubHeader}>{customWorkoutDraft.daysPerWeek} day{customWorkoutDraft.daysPerWeek === 1 ? '' : 's'} per week</div>
                 <div style={templatesCustomStyles.summaryList}>
                   {customWorkoutDraft.days.map((day, index) => (
                     <div key={day.id} style={templatesCustomStyles.summaryDayCard}>
                       <div style={templatesCustomStyles.summaryDayTitle}>{day.name.trim() || `Day ${index + 1}`}</div>
                       {day.exercises.length === 0 ? (
                         <div style={templatesCustomStyles.emptyExerciseText}>No exercises selected</div>
-                      ) : day.exercises.map(ex => (
-                        <div key={`${day.id}-${ex.id}-summary`} style={templatesCustomStyles.summaryExerciseRow}>
-                          <span>{ex.name}</span>
-                          <span style={templatesCustomStyles.summaryDefaults}>3 sets · 8-12 reps · 20kg</span>
+                      ) : day.exercises.map((de, ei) => (
+                        <div key={`${day.id}-${de.exercise.id}-summary-${ei}`} style={templatesCustomStyles.summaryExerciseRow}>
+                          <span>{de.exercise.name}</span>
+                          <span style={templatesCustomStyles.summaryDefaults}>
+                            {de.sets} set{de.sets !== 1 ? 's' : ''} {'\u00B7'} {de.reps} rep{de.reps !== 1 ? 's' : ''} {'\u00B7'} {de.weightKg}kg
+                          </span>
                         </div>
                       ))}
                     </div>
@@ -1288,87 +1232,6 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                 </button>
               )}
             </div>
-          </div>
-        </div>
-      )}
-
-      {showBuilderExerciseBrowser && (
-        <div
-          style={S.overlay}
-          onClick={() => {
-            setShowBuilderExerciseBrowser(false);
-            setBuilderActiveDayId(null);
-            setExSearch('');
-            setExEquipment('All');
-            setExMuscle('All');
-          }}
-        >
-          <div style={{ ...S.addExModal, maxHeight: '85vh', overflowY: 'auto' }} onClick={e => e.stopPropagation()}>
-            <h3 style={S.addExTitle}>Add Exercise</h3>
-            <p style={S.addExSub}>Add to {builderDraftDays.find(day => day.id === builderActiveDayId)?.name}</p>
-            <input
-              type="text"
-              placeholder="Search exercises..."
-              value={exSearch}
-              onChange={e => setExSearch(e.target.value)}
-              style={ebStyles.searchInput}
-            />
-            <div style={ebStyles.filterRow}>
-              <select
-                value={exEquipment}
-                onChange={e => setExEquipment(e.target.value as EquipmentFilter)}
-                style={ebStyles.select}
-              >
-                <option value="All">All Equipment</option>
-                {EQUIPMENT_FILTER_OPTIONS.map(eq => (
-                  <option key={eq} value={eq} style={ebStyles.option}>{eq}</option>
-                ))}
-              </select>
-              <select
-                value={exMuscle}
-                onChange={e => setExMuscle(e.target.value as MuscleFilter)}
-                style={ebStyles.select}
-              >
-                <option value="All">All Muscles</option>
-                {MUSCLE_FILTER_OPTIONS.map(m => (
-                  <option key={m} value={m} style={ebStyles.option}>{m}</option>
-                ))}
-              </select>
-            </div>
-            <p style={ebStyles.resultCount}>
-              {filteredExercises.length > 0
-                ? `${filteredExercises.length} exercise${filteredExercises.length !== 1 ? 's' : ''}`
-                : 'No exercises match these filters'}
-            </p>
-            <div style={S.addExList}>
-              {filteredExercises.map(ex => (
-                <div key={ex.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <button onClick={() => addBuilderExercise(ex)} style={{ ...S.addExItem, flex: 1 }}>
-                    <div>
-                      <div style={S.addExName}>{ex.name}</div>
-                      <div style={S.addExMeta}>
-                        {ex.muscle} {'·'} {ex.equipment === 'None' ? 'Bodyweight' : ex.equipment}
-                        {ex.isBodyweight ? '' : ' · Weighted'}
-                      </div>
-                    </div>
-                    <div style={S.addExArrow}>+</div>
-                  </button>
-                  <button onClick={() => setShowHowTo(ex)} style={howToBtn}>?</button>
-                </div>
-              ))}
-            </div>
-            <button
-              onClick={() => {
-                setShowBuilderExerciseBrowser(false);
-                setBuilderActiveDayId(null);
-                setExSearch('');
-                setExEquipment('All');
-                setExMuscle('All');
-              }}
-              style={S.addExCancel}
-            >
-              CANCEL
-            </button>
           </div>
         </div>
       )}
@@ -1583,8 +1446,15 @@ const templatesCustomStyles: Record<string, React.CSSProperties> = {
   dayAddBtn: { borderRadius: radii.sm, border: `1px solid ${colors.primaryBorder}`, background: 'rgba(255,59,48,0.08)', color: colors.primary, padding: `4px ${spacing.sm}px`, fontSize: typography.sizes.xs, fontWeight: typography.weights.bold },
   dayExerciseList: { display: 'flex', flexDirection: 'column', gap: 6, marginBottom: spacing.sm },
   dayEmpty: { color: colors.textTertiary, fontSize: typography.sizes.xs },
-  dayExerciseRow: { display: 'grid', gridTemplateColumns: '28px 1fr 68px 52px 52px', alignItems: 'center', gap: 6 },
-  rowRemoveBtn: { width: 28, height: 28, borderRadius: radii.sm, border: 'none', background: 'rgba(255,59,48,0.14)', color: colors.primary, fontSize: typography.sizes.lg, lineHeight: '28px', padding: 0 },
+  dayExerciseRow: { display: 'grid', gridTemplateColumns: '28px 1fr 52px 52px 60px 28px', alignItems: 'center', gap: 6 },
+  rowOrderBtns: { display: 'flex', flexDirection: 'column' as const, gap: 2 },
+  rowOrderBtn: { width: 24, height: 16, borderRadius: radii.sm, border: `1px solid ${colors.surfaceBorder}`, background: 'rgba(255,255,255,0.06)', color: colors.text, fontSize: '0.6rem', lineHeight: 1, padding: 0, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' },
+  rowOrderBtnDisabled: { opacity: 0.3, cursor: 'not-allowed' },
+  rowRemoveBtn: { width: 28, height: 28, borderRadius: radii.sm, border: 'none', background: 'rgba(255,59,48,0.14)', color: colors.primary, fontSize: typography.sizes.lg, lineHeight: '28px', padding: 0, cursor: 'pointer' },
+  rowHeaderLabels: { display: 'grid', gridTemplateColumns: '28px 1fr 52px 52px 60px 28px', gap: 6, marginBottom: 4 },
+  rowHeaderLabel: { color: colors.textTertiary, fontSize: '0.6rem', fontWeight: typography.weights.bold, textTransform: 'uppercase' as const, textAlign: 'center' as const },
+  rowHeaderSpacer: {},
+  rowHeaderRemoveSpacer: {},
   rowMeta: { minWidth: 0 },
   rowName: { color: colors.text, fontSize: typography.sizes.xs, fontWeight: typography.weights.bold, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' },
   rowSub: { color: colors.textTertiary, fontSize: '0.65rem' },
@@ -1592,7 +1462,8 @@ const templatesCustomStyles: Record<string, React.CSSProperties> = {
   emptyExerciseText: { color: colors.textSecondary, fontSize: typography.sizes.xs },
   exerciseItem: { color: colors.text, fontSize: typography.sizes.sm },
   addExerciseBtn: { width: '100%', borderRadius: radii.md, border: `1px solid ${colors.primaryBorder}`, background: 'rgba(255,59,48,0.08)', color: colors.primary, padding: `4px ${spacing.sm}px`, fontSize: typography.sizes.xs, fontWeight: typography.weights.bold },
-  summaryHeader: { color: colors.text, fontWeight: typography.weights.black, fontSize: typography.sizes.lg, marginBottom: spacing.sm },
+  summaryHeader: { color: colors.text, fontWeight: typography.weights.black, fontSize: typography.sizes.lg, marginBottom: 2 },
+  summarySubHeader: { color: colors.textSecondary, fontSize: typography.sizes.sm, marginBottom: spacing.sm },
   summaryList: { display: 'flex', flexDirection: 'column', gap: spacing.sm, maxHeight: '46vh', overflowY: 'auto', marginBottom: spacing.sm, paddingRight: 2 },
   summaryDayCard: { borderRadius: radii.md, border: `1px solid ${colors.surfaceBorder}`, padding: spacing.sm, background: 'rgba(255,255,255,0.03)' },
   summaryDayTitle: { color: colors.text, fontWeight: typography.weights.bold, marginBottom: 6 },


### PR DESCRIPTION
## Summary
Consolidated the custom workout builder UI to use a single `CustomWorkoutDraft` state object instead of managing separate state variables for name, days, and draft days. This simplifies state management and unifies the builder experience across all steps.

## Key Changes
- **Removed duplicate state management**: Eliminated `customWorkoutName`, `customWorkoutDays`, `builderDraftDays`, and `builderActiveDayId` state variables in favor of the existing `customWorkoutDraft` state
- **Removed old builder modal**: Deleted the initial workout configuration modal that collected name and days separately
- **Unified exercise management**: Consolidated `BuilderDraftExercise` and `CustomWorkoutDraftExercise` into a single interface, ensuring all draft exercises store complete exercise metadata (sets, reps, weight)
- **Refactored exercise operations**: Updated `updateBuilderExerciseField`, `removeBuilderExercise`, and `addBuilderExercise` to work with the unified `customWorkoutDraft` state
- **Added exercise reordering**: Implemented `reorderDraftExercise` function to allow users to reorder exercises within a day using up/down buttons
- **Enhanced step 3 UI**: Improved the "Name each day & add exercises" step with:
  - Exercise reordering controls (up/down arrows)
  - Inline exercise parameter editing (sets, reps, weight)
  - Column headers for better clarity
  - Proper input validation with `Math.max()` constraints
- **Improved step 4 review**: Updated summary display to show actual exercise parameters instead of hardcoded defaults
- **Removed old exercise browser modal**: Deleted `showBuilderExerciseBrowser` state and its associated modal UI
- **Simplified exercise addition**: Exercise selection now directly updates `customWorkoutDraft` when a day is selected

## Implementation Details
- Exercise draft objects now consistently include `exercise`, `sets`, `reps`, and `weightKg` properties throughout the builder flow
- The `dayExerciseRow` grid layout was adjusted to accommodate reordering buttons and maintain proper alignment
- Input fields now use `Math.max()` to enforce minimum values (1 for sets/reps, 0 for weight)
- The review step (step 4) now displays actual configured values with proper pluralization

https://claude.ai/code/session_01J6M81jM7RzWjgMYdU8PVb3