### PR TITLE
Add progression banner display for exercise weight/rep changes

### DIFF
--- a/src/features/workout/WorkoutContext.tsx
+++ b/src/features/workout/WorkoutContext.tsx
@@ -36,6 +36,7 @@ interface WorkoutContextValue {
   completedSets: Record<string, number>;
   currentLog: SetLog[];
   restTimerFor: string | null;
+  progressions: Record<string, ProgressionResult | null>;
   workoutHistory: WorkoutLog[];
   exerciseHistory: ExerciseHistory;
   personalRecords: PersonalRecords;
@@ -223,6 +224,12 @@ export function WorkoutProvider({ children, dayExercises, currentDayName, onProg
       if (progression && onProgression) {
         onProgression({ ...progression, exerciseId: pe.id });
       }
+
+      dispatch({
+        type: 'SET_PROGRESSION',
+        exerciseId: pe.id,
+        result: progression ? { ...progression, exerciseId: pe.id } : null,
+      });
     }
   }, [state.completedSets, personalRecords, demo, persistPRs, onProgression]);
 
@@ -384,6 +391,7 @@ export function WorkoutProvider({ children, dayExercises, currentDayName, onProg
       completedSets: state.completedSets,
       currentLog: state.currentLog,
       restTimerFor: state.restTimerFor,
+      progressions: state.progressions,
       workoutHistory,
       exerciseHistory,
       personalRecords,

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -16,6 +16,7 @@ import type { UserProfile } from '@/shared/types';
 import { useTier } from '@/hooks/useTier';
 import { calculateFatigueScore } from '@/training/fatigue';
 import { evaluateSuggestions } from '@/training/suggestions';
+import { formatProgressionBanner } from '@/training/progression';
 import type { WorkoutSuggestion } from '@/training/suggestions';
 import { SuggestionToast } from './SuggestionToast';
 import { ReadinessCheck, getTodayReadiness } from '@/features/readiness/ReadinessCheck';
@@ -599,11 +600,23 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                     />
                   )}
                 </div>
-                <div style={S.stat}>
-                  <div style={S.statLabel}>NEXT</div>
-                  <div style={S.statValGreen}>+{pe.progressionKg}</div>
-                </div>
               </div>
+
+              {isDone && !pe.exercise.isBodyweight && pe.id in workout.progressions && (() => {
+                const banner = formatProgressionBanner(
+                  workout.progressions[pe.id],
+                  pe.weightKg,
+                );
+                return (
+                  <div style={progressionBannerStyles[banner.tone]}>
+                    <span style={progressionBannerStyles.icon}>{banner.icon}</span>
+                    <div>
+                      <div style={progressionBannerStyles.label}>{banner.label}</div>
+                      <div style={progressionBannerStyles.subtext}>{banner.subtext}</div>
+                    </div>
+                  </div>
+                );
+              })()}
 
               {!isDone && (
                 <button
@@ -1472,4 +1485,22 @@ const templatesCustomStyles: Record<string, React.CSSProperties> = {
   actions: { display: 'flex', gap: spacing.sm, justifyContent: 'flex-end' },
   cancel: { borderRadius: radii.md, border: `1px solid ${colors.surfaceBorder}`, background: 'transparent', color: colors.textSecondary, padding: `${spacing.sm}px ${spacing.md}px` },
   create: { borderRadius: radii.md, border: 'none', background: colors.primary, color: '#fff', padding: `${spacing.sm}px ${spacing.md}px`, fontWeight: typography.weights.bold },
+};
+
+const progressionBannerBase: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: spacing.sm,
+  padding: `${spacing.sm + 2}px ${spacing.md}px`,
+  borderRadius: radii.lg,
+  marginBottom: spacing.md,
+};
+
+const progressionBannerStyles: Record<string, React.CSSProperties> = {
+  success: { ...progressionBannerBase, background: colors.successSurface, border: `1px solid ${colors.successBorder}` },
+  warning: { ...progressionBannerBase, background: colors.warningSurface, border: `1px solid ${colors.warningBorder}` },
+  neutral: { ...progressionBannerBase, background: colors.surface, border: `1px solid ${colors.surfaceBorder}` },
+  icon: { fontSize: typography.sizes['3xl'], fontWeight: typography.weights.black, lineHeight: '1.2', flexShrink: 0 },
+  label: { fontSize: typography.sizes.md, fontWeight: typography.weights.bold, color: colors.text },
+  subtext: { fontSize: typography.sizes.sm, color: colors.textSecondary, marginTop: 2 },
 };

--- a/src/features/workout/workout.reducer.test.ts
+++ b/src/features/workout/workout.reducer.test.ts
@@ -145,6 +145,49 @@ describe('workoutReducer', () => {
       expect(state.completedSets).toEqual({});
       expect(state.currentLog).toEqual([]);
       expect(state.restTimerFor).toBeNull();
+      expect(state.progressions).toEqual({});
+    });
+  });
+
+  describe('SET_PROGRESSION', () => {
+    it('stores a progression result for an exercise', () => {
+      const result = {
+        exerciseId: 'ex1',
+        field: 'weightKg' as const,
+        oldValue: 80,
+        newValue: 82.5,
+        reason: 'Target reps reached',
+      };
+      const state = workoutReducer(initialWorkoutState, {
+        type: 'SET_PROGRESSION',
+        exerciseId: 'ex1',
+        result,
+      });
+
+      expect(state.progressions['ex1']).toEqual(result);
+    });
+
+    it('stores null for no-change progression', () => {
+      const state = workoutReducer(initialWorkoutState, {
+        type: 'SET_PROGRESSION',
+        exerciseId: 'ex1',
+        result: null,
+      });
+
+      expect(state.progressions['ex1']).toBeNull();
+      expect('ex1' in state.progressions).toBe(true);
+    });
+
+    it('clears progressions on RESET', () => {
+      let state = workoutReducer(initialWorkoutState, {
+        type: 'SET_PROGRESSION',
+        exerciseId: 'ex1',
+        result: null,
+      });
+
+      state = workoutReducer(state, { type: 'RESET' });
+
+      expect(state.progressions).toEqual({});
     });
   });
 

--- a/src/features/workout/workout.reducer.ts
+++ b/src/features/workout/workout.reducer.ts
@@ -1,20 +1,24 @@
 import type { SetLog, CompletedSets } from '@/shared/types';
+import type { ProgressionResult } from '@/training/progression';
 
 export interface WorkoutState {
   completedSets: CompletedSets;
   currentLog: SetLog[];
   restTimerFor: string | null;
+  progressions: Record<string, ProgressionResult | null>;
 }
 
 export type WorkoutAction =
   | { type: 'COMPLETE_SET'; exerciseId: string; setNumber: number; log: SetLog }
   | { type: 'SET_REST_FOR'; exerciseId: string | null }
+  | { type: 'SET_PROGRESSION'; exerciseId: string; result: ProgressionResult | null }
   | { type: 'RESET' };
 
 export const initialWorkoutState: WorkoutState = {
   completedSets: {},
   currentLog: [],
   restTimerFor: null,
+  progressions: {},
 };
 
 export function workoutReducer(state: WorkoutState, action: WorkoutAction): WorkoutState {
@@ -32,6 +36,15 @@ export function workoutReducer(state: WorkoutState, action: WorkoutAction): Work
 
     case 'SET_REST_FOR':
       return { ...state, restTimerFor: action.exerciseId };
+
+    case 'SET_PROGRESSION':
+      return {
+        ...state,
+        progressions: {
+          ...state.progressions,
+          [action.exerciseId]: action.result,
+        },
+      };
 
     case 'RESET':
       return initialWorkoutState;

--- a/src/shared/theme/styles.ts
+++ b/src/shared/theme/styles.ts
@@ -82,7 +82,7 @@ export const S: Record<string, CSSProperties> = {
   warmupVal: { fontWeight: typography.weights.bold },
 
   // Stats grid
-  stats: { display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: spacing.sm, marginTop: spacing.md, marginBottom: spacing.xl - 6 },
+  stats: { display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: spacing.sm, marginTop: spacing.md, marginBottom: spacing.xl - 6 },
   stat: { padding: `${spacing.sm + 2}px ${spacing.sm}px`, borderRadius: radii.lg, background: colors.surface, border: '1px solid rgba(255,255,255,0.05)', textAlign: 'center' },
   statLabel: { fontSize: typography.sizes.xs, color: colors.textTertiary, fontWeight: typography.weights.black, marginBottom: 4, letterSpacing: '0.03em' },
   statVal: { fontSize: typography.sizes.xl, fontWeight: typography.weights.black, color: colors.text },

--- a/src/training/index.ts
+++ b/src/training/index.ts
@@ -4,5 +4,5 @@ export type { FatigueResult, FatigueFactor, FatigueTrend, SuggestedAction } from
 export { evaluateSuggestions } from './suggestions';
 export type { WorkoutSuggestion, SuggestionEvent, SuggestionType, SuggestionPriority } from './suggestions';
 
-export { calculateProgression } from './progression';
-export type { ProgressionResult, ProgressionExercise } from './progression';
+export { calculateProgression, formatProgressionBanner } from './progression';
+export type { ProgressionResult, ProgressionExercise, ProgressionBanner } from './progression';

--- a/src/training/progression.test.ts
+++ b/src/training/progression.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculateProgression } from './progression';
+import { calculateProgression, formatProgressionBanner } from './progression';
 
 describe('calculateProgression', () => {
   it('increases reps for RPE 6 with reps below target', () => {
@@ -45,5 +45,78 @@ describe('calculateProgression', () => {
       oldValue: 0,
       newValue: 0,
     });
+  });
+});
+
+describe('formatProgressionBanner', () => {
+  it('shows weight increase with success tone', () => {
+    const result = {
+      exerciseId: 'ex1',
+      field: 'weightKg' as const,
+      oldValue: 80,
+      newValue: 82.5,
+      reason: 'Target reps reached, progressing weight',
+    };
+    const banner = formatProgressionBanner(result, 80);
+
+    expect(banner.tone).toBe('success');
+    expect(banner.icon).toBe('\u2191');
+    expect(banner.label).toContain('82.5kg');
+    expect(banner.label).toContain('+2.5kg');
+  });
+
+  it('shows weight decrease with warning tone', () => {
+    const result = {
+      exerciseId: 'ex1',
+      field: 'weightKg' as const,
+      oldValue: 80,
+      newValue: 77.5,
+      reason: 'RPE 10 - reducing weight for safety',
+    };
+    const banner = formatProgressionBanner(result, 80);
+
+    expect(banner.tone).toBe('warning');
+    expect(banner.icon).toBe('\u2193');
+    expect(banner.label).toContain('77.5kg');
+    expect(banner.label).toContain('-2.5kg');
+  });
+
+  it('shows rep increase with success tone', () => {
+    const result = {
+      exerciseId: 'ex1',
+      field: 'reps' as const,
+      oldValue: 8,
+      newValue: 9,
+      reason: 'RPE indicates room for more reps',
+    };
+    const banner = formatProgressionBanner(result, 80);
+
+    expect(banner.tone).toBe('success');
+    expect(banner.icon).toBe('\u2191');
+    expect(banner.label).toContain('80kg');
+    expect(banner.label).toContain('9 reps');
+    expect(banner.label).toContain('+1 rep');
+    expect(banner.label).not.toContain('+1 reps');
+  });
+
+  it('pluralizes reps correctly for multi-rep increase', () => {
+    const result = {
+      exerciseId: 'ex1',
+      field: 'reps' as const,
+      oldValue: 6,
+      newValue: 8,
+      reason: 'RPE indicates room for more reps',
+    };
+    const banner = formatProgressionBanner(result, 60);
+
+    expect(banner.label).toContain('+2 reps');
+  });
+
+  it('shows neutral banner for null result (no change)', () => {
+    const banner = formatProgressionBanner(null, 80);
+
+    expect(banner.tone).toBe('neutral');
+    expect(banner.icon).toBe('\u2192');
+    expect(banner.label).toContain('same weight');
   });
 });

--- a/src/training/progression.ts
+++ b/src/training/progression.ts
@@ -53,3 +53,50 @@ export function calculateProgression(
 
   return null;
 }
+
+export interface ProgressionBanner {
+  icon: string;
+  label: string;
+  subtext: string;
+  tone: 'success' | 'warning' | 'neutral';
+}
+
+export function formatProgressionBanner(
+  result: ProgressionResult | null,
+  currentWeightKg: number,
+): ProgressionBanner {
+  if (!result) {
+    return {
+      icon: '\u2192',
+      label: 'Next session: same weight',
+      subtext: 'Good effort \u2014 maintain current load',
+      tone: 'neutral',
+    };
+  }
+
+  if (result.field === 'weightKg') {
+    const diff = result.newValue - result.oldValue;
+    if (diff > 0) {
+      return {
+        icon: '\u2191',
+        label: `Next session: ${result.newValue}kg (+${diff}kg)`,
+        subtext: result.reason,
+        tone: 'success',
+      };
+    }
+    return {
+      icon: '\u2193',
+      label: `Next session: ${result.newValue}kg (${diff}kg)`,
+      subtext: result.reason,
+      tone: 'warning',
+    };
+  }
+
+  const repDiff = result.newValue - result.oldValue;
+  return {
+    icon: '\u2191',
+    label: `Next session: ${currentWeightKg}kg \u00d7 ${result.newValue} reps (+${repDiff} rep${repDiff !== 1 ? 's' : ''})`,
+    subtext: result.reason,
+    tone: 'success',
+  };
+}


### PR DESCRIPTION
## Summary
This PR adds visual feedback for exercise progression by displaying formatted banners that show weight and rep changes after completing a workout. The progression results are now stored in the workout state and rendered with appropriate visual styling based on the type of change.

## Key Changes
- **New `formatProgressionBanner` function** in `progression.ts` that converts progression results into formatted banner objects with icon, label, subtext, and tone (success/warning/neutral)
- **Workout state enhancement** with a new `progressions` record to store progression results per exercise
- **SET_PROGRESSION action** added to the workout reducer to manage progression state updates
- **Visual progression banners** displayed in WorkoutView after exercise completion, showing:
  - Weight increases (success tone with ↑ icon)
  - Weight decreases (warning tone with ↓ icon)
  - Rep increases (success tone with ↑ icon)
  - No change scenarios (neutral tone with → icon)
- **Proper pluralization** of rep changes ("+1 rep" vs "+2 reps")
- **Styling** for progression banners with theme-aware colors and typography
- **Context updates** to expose progressions through WorkoutContext
- **Comprehensive test coverage** for the new `formatProgressionBanner` function and SET_PROGRESSION reducer action

## Implementation Details
- The progression banner replaces the previous static "+{progressionKg}" display
- Banners only show for non-bodyweight exercises when a progression result exists
- The `currentWeightKg` is passed to the formatter to display weight context for rep-only changes
- Progression results are dispatched to the reducer whenever sets are completed and progression is calculated
- The banner styling uses the existing design system tokens (colors, spacing, typography)

https://claude.ai/code/session_01L7SJGrsB4ZUXqbxBjSeesQ