### PR TITLE
Centralize storage clearing with `clearAllStorage` and use it in Profile reset

### DIFF
--- a/src/features/profile/Profile.tsx
+++ b/src/features/profile/Profile.tsx
@@ -9,7 +9,7 @@ import {
   loadProfile, saveProfile,
   loadWorkoutHistory, loadExerciseHistory, loadPersonalRecords,
   loadBodyMeasurements,
-  StorageKeys,
+  clearAllStorage,
 } from '@/shared/storage';
 import { processProfilePhoto } from '@/shared/utils/imageProcessing';
 import { formatVolume } from '@/shared/utils';
@@ -66,8 +66,7 @@ export function Profile({ profile, onProfileUpdate }: ProfileProps) {
   }, []);
 
   const handleReset = useCallback(() => {
-    Object.values(StorageKeys).forEach(key => localStorage.removeItem(key));
-    localStorage.removeItem('ironStorageVersion');
+    clearAllStorage();
     window.location.reload();
   }, []);
 

--- a/src/shared/storage/storage.test.ts
+++ b/src/shared/storage/storage.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { loadTrainingPlan, StorageKeys } from './storage';
+import { clearAllStorage, loadTrainingPlan, StorageKeys } from './storage';
 
 describe('loadTrainingPlan', () => {
   beforeEach(() => {
@@ -33,5 +33,25 @@ describe('loadTrainingPlan', () => {
     expect(plan?.dayIndex).toBe(1);
     expect(plan?.exercises).toHaveLength(1);
     expect(plan?.exercises[0].dayId).toBe('d2');
+  });
+});
+
+describe('clearAllStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('removes all known storage keys and version key', () => {
+    Object.values(StorageKeys).forEach((key) => {
+      localStorage.setItem(key, 'mock');
+    });
+    localStorage.setItem('ironStorageVersion', '3');
+
+    clearAllStorage();
+
+    Object.values(StorageKeys).forEach((key) => {
+      expect(localStorage.getItem(key)).toBeNull();
+    });
+    expect(localStorage.getItem('ironStorageVersion')).toBeNull();
   });
 });

--- a/src/shared/storage/storage.ts
+++ b/src/shared/storage/storage.ts
@@ -256,6 +256,13 @@ export function saveLastWorkoutWeek(week: number): void {
   localStorage.setItem(StorageKeys.LAST_WORKOUT_WEEK, week.toString());
 }
 
+export function clearAllStorage(): void {
+  Object.values(StorageKeys).forEach((key) => {
+    localStorage.removeItem(key);
+  });
+  localStorage.removeItem(STORAGE_VERSION_KEY);
+}
+
 function normalizeTrainingPlanState(parsed: unknown): TrainingPlanState | null {
   if (!parsed || typeof parsed !== 'object') return null;
 


### PR DESCRIPTION
### Motivation
- Replace duplicated direct `localStorage` deletes in the UI with a single shared helper to ensure consistent behavior and reduce duplication.

### Description
- Add `clearAllStorage()` to `src/shared/storage/storage.ts` which removes every key in `StorageKeys` and the storage version key (`STORAGE_VERSION_KEY`).
- Update the profile reset flow in `src/features/profile/Profile.tsx` to call `clearAllStorage()` from the shared storage API instead of manually removing keys.
- Add a unit test in `src/shared/storage/storage.test.ts` that validates `clearAllStorage()` removes all declared storage keys and the `ironStorageVersion` entry.

### Testing
- Ran lint with `npm run lint` and it completed successfully.
- Ran the full test suite with `npm test` (Vitest) and all tests passed, including the new `clearAllStorage` test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6a596798833085616ccb9506b098)