### PR TITLE
feat: add loading & transition polish (cross-fade tabs, skeletons, sp…

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
     <title>Iron Protocol</title>
+    <script>window.__splashStart = Date.now();</script>
 
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -63,20 +64,12 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        transition: opacity 0.4s ease, visibility 0.4s ease;
+        transition: opacity 0.15s ease, visibility 0.15s ease;
       }
       #splash.hide {
         opacity: 0;
         visibility: hidden;
         pointer-events: none;
-      }
-
-      /* Dumbbell icon */
-      .splash-icon {
-        width: 64px;
-        height: 64px;
-        margin-bottom: 24px;
-        animation: splashPulse 2s ease-in-out infinite;
       }
 
       /* Wordmark */
@@ -87,54 +80,29 @@
         letter-spacing: 6px;
         color: #fff;
         text-transform: uppercase;
-        animation: splashPulse 2s ease-in-out infinite;
       }
 
-      /* Loading bar */
-      .splash-loader {
-        margin-top: 32px;
-        width: 120px;
-        height: 3px;
-        background: rgba(255,255,255,0.08);
-        border-radius: 2px;
-        overflow: hidden;
-      }
-      .splash-loader-bar {
-        width: 40%;
-        height: 100%;
-        background: #FF3B30;
-        border-radius: 2px;
-        animation: splashLoad 1.2s ease-in-out infinite;
+      /* Red pulse ring */
+      .splash-pulse {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        border: 2px solid #FF3B30;
+        margin-top: 24px;
+        animation: splashRingPulse 0.8s ease-in-out infinite;
       }
 
-      @keyframes splashPulse {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.6; }
-      }
-      @keyframes splashLoad {
-        0% { transform: translateX(-100%); }
-        100% { transform: translateX(350%); }
+      @keyframes splashRingPulse {
+        0%, 100% { transform: scale(1); opacity: 0.5; box-shadow: 0 0 0 0 rgba(255,59,48,0); }
+        50%       { transform: scale(1.1); opacity: 1; box-shadow: 0 0 12px 4px rgba(255,59,48,0.3); }
       }
     </style>
   </head>
   <body>
     <!-- Splash Screen (visible while JS loads) -->
     <div id="splash">
-      <svg class="splash-icon" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <g transform="translate(32,32)">
-          <rect x="-24" y="-14" width="6" height="28" rx="2" fill="#FF3B30"/>
-          <rect x="18" y="-14" width="6" height="28" rx="2" fill="#FF3B30"/>
-          <rect x="-18" y="-10" width="5" height="20" rx="2" fill="#FF3B30" opacity="0.75"/>
-          <rect x="13" y="-10" width="5" height="20" rx="2" fill="#FF3B30" opacity="0.75"/>
-          <rect x="-13" y="-2" width="26" height="4" rx="2" fill="#fff" opacity="0.9"/>
-          <rect x="-27" y="-2" width="3" height="4" rx="1.5" fill="#fff" opacity="0.5"/>
-          <rect x="24" y="-2" width="3" height="4" rx="1.5" fill="#fff" opacity="0.5"/>
-        </g>
-      </svg>
       <div class="splash-wordmark">Iron Protocol</div>
-      <div class="splash-loader">
-        <div class="splash-loader-bar"></div>
-      </div>
+      <div class="splash-pulse"></div>
     </div>
 
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -21,8 +21,13 @@ runMigrations();
 function dismissSplash() {
   const splash = document.getElementById('splash');
   if (!splash) return;
-  splash.classList.add('hide');
-  window.setTimeout(() => splash.remove(), TIMINGS.ANIMATION_SLOW);
+  const splashStart = (window as Window & { __splashStart?: number }).__splashStart ?? Date.now();
+  const elapsed = Date.now() - splashStart;
+  const delay = Math.max(0, 300 - elapsed);
+  window.setTimeout(() => {
+    splash.classList.add('hide');
+    window.setTimeout(() => splash.remove(), TIMINGS.ANIMATION_FAST);
+  }, delay);
 }
 
 function useHashRoute() {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy, useCallback, useMemo, useRef, useState } from 'react';
 import type { UserProfile } from '@/shared/types';
-import { Icon, LoadingSpinner } from '@/shared/components';
+import { Icon, LoadingSpinner, WorkoutSkeleton, DashboardSkeleton, QuickWorkoutSkeleton, HomeSkeleton, ProfileSkeleton } from '@/shared/components';
 import { S, globalCss } from '@/shared/theme/styles';
 import { colors } from '@/shared/theme/tokens';
 import { getGreeting } from '@/shared/utils';
@@ -124,11 +124,19 @@ export function AppShell({ profile, onProfileUpdate }: { profile: UserProfile; o
       >
         {activeTab === 'dashboard' && (pull.pullDistance > 0 || isRefreshing) && <div style={{ ...S.pullRefresh, height: isRefreshing ? 50 : Math.min(pull.pullDistance, 60) }}><span style={{ ...S.pullRefreshSpinner, animation: isRefreshing ? 'pullRefreshSpin 0.8s linear infinite' : 'none' }}><Icon name="refresh" size={22} /></span></div>}
 
-        <Suspense fallback={<LoadingSpinner />}>
-          <div className={transitionClass} key={activeTab}>
-            {activeTab === 'home' && <HomeTab profile={profile} onNavigateToWorkout={() => handleTabSwitch('workout')} />}
-            {activeTab === 'workout' && <WorkoutView profile={profile} />}
-            {activeTab === 'dashboard' && (
+        <div className={transitionClass} key={activeTab}>
+          {activeTab === 'home' && (
+            <Suspense fallback={<HomeSkeleton />}>
+              <HomeTab profile={profile} onNavigateToWorkout={() => handleTabSwitch('workout')} />
+            </Suspense>
+          )}
+          {activeTab === 'workout' && (
+            <Suspense fallback={<WorkoutSkeleton />}>
+              <WorkoutView profile={profile} />
+            </Suspense>
+          )}
+          {activeTab === 'dashboard' && (
+            <Suspense fallback={<DashboardSkeleton />}>
               <Dashboard
                 profile={profile}
                 streak={currentStreak}
@@ -137,11 +145,19 @@ export function AppShell({ profile, onProfileUpdate }: { profile: UserProfile; o
                 demoMode={demoMode.enabled}
                 onToggleDemo={demoMode.setEnabled}
               />
-            )}
-            {activeTab === 'quick' && <QuickWorkoutList onStart={setQuickWorkout} onClose={() => handleTabSwitch('workout')} inline />}
-            {activeTab === 'profile' && <Profile profile={profile} onProfileUpdate={onProfileUpdate} />}
-          </div>
-        </Suspense>
+            </Suspense>
+          )}
+          {activeTab === 'quick' && (
+            <Suspense fallback={<QuickWorkoutSkeleton />}>
+              <QuickWorkoutList onStart={setQuickWorkout} onClose={() => handleTabSwitch('workout')} inline />
+            </Suspense>
+          )}
+          {activeTab === 'profile' && (
+            <Suspense fallback={<ProfileSkeleton />}>
+              <Profile profile={profile} onProfileUpdate={onProfileUpdate} />
+            </Suspense>
+          )}
+        </div>
       </main>
 
       {showMeasurements && <MeasurementsModal currentWeight={profile.weight} onSave={(data) => { progress.saveMeasurement(data); setShowMeasurements(false); }} onClose={() => setShowMeasurements(false)} />}

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -395,7 +395,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
 
   const handleDayChange = (index: number) => {
     if (index === plan.dayIndex) return;
-    const animClass = index > plan.dayIndex ? 'tab-enter-right' : 'tab-enter-left';
+    const animClass = index > plan.dayIndex ? 'day-enter-right' : 'day-enter-left';
     plan.setDayIndex(index);
     workout.resetWorkoutState();
     setDayAnimKey(prev => prev + 1);

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -4,6 +4,7 @@ export { ErrorBoundary } from './ErrorBoundary';
 export { FeatureGate } from './FeatureGate';
 
 export { LoadingSpinner } from './LoadingSpinner';
+export { WorkoutSkeleton, DashboardSkeleton, QuickWorkoutSkeleton, HomeSkeleton, ProfileSkeleton } from './skeletons';
 export { InlineEdit } from './InlineEdit';
 export type { InlineEditProps } from './InlineEdit';
 export { ExerciseBrowserModal } from './ExerciseBrowserModal';

--- a/src/shared/components/skeletons.tsx
+++ b/src/shared/components/skeletons.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { radii, spacing } from '@/shared/theme/tokens';
+
+function skBlock(w: string | number, h: number, br?: number): React.CSSProperties {
+  return {
+    width: w,
+    height: h,
+    borderRadius: br ?? radii.lg,
+    background: '#1a1a1a',
+    animation: 'skeletonPulse 1.6s ease-in-out infinite',
+    flexShrink: 0,
+  };
+}
+
+const wrap: React.CSSProperties = {
+  padding: spacing.lg,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.md,
+};
+
+export function WorkoutSkeleton() {
+  return (
+    <div style={wrap}>
+      {/* Day pills row */}
+      <div style={{ display: 'flex', gap: spacing.sm }}>
+        {[60, 56, 64, 52].map((w, i) => (
+          <div key={i} style={skBlock(w, 32, radii.pill)} />
+        ))}
+      </div>
+      {/* Progress bar card */}
+      <div style={skBlock('100%', 48, radii.xl)} />
+      {/* Exercise cards */}
+      {[0, 1, 2].map((i) => (
+        <div key={i} style={{ ...skBlock('100%', 80, radii.lg), padding: spacing.md, display: 'flex', flexDirection: 'column', gap: spacing.sm }}>
+          <div style={skBlock('60%', 16, radii.sm)} />
+          {[0, 1, 2].map((j) => <div key={j} style={skBlock('100%', 12, radii.sm)} />)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardSkeleton() {
+  return (
+    <div style={wrap}>
+      {/* 2×2 stat grid */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: spacing.md }}>
+        {[0, 1, 2, 3].map((i) => <div key={i} style={skBlock('100%', 70, radii.xl)} />)}
+      </div>
+      {/* Chart area */}
+      <div style={skBlock('100%', 120, radii.xl)} />
+      {/* Insight cards */}
+      <div style={skBlock('100%', 60, radii.lg)} />
+      <div style={skBlock('100%', 60, radii.lg)} />
+    </div>
+  );
+}
+
+export function QuickWorkoutSkeleton() {
+  return (
+    <div style={wrap}>
+      <div style={skBlock(180, 20, radii.md)} />
+      <div style={skBlock(100, 14, radii.sm)} />
+      {[0, 1, 2, 3].map((i) => <div key={i} style={skBlock('100%', 64, radii.lg)} />)}
+    </div>
+  );
+}
+
+export function HomeSkeleton() {
+  return (
+    <div style={wrap}>
+      {/* Calendar strip */}
+      <div style={skBlock('100%', 56, radii.md)} />
+      {/* Greeting */}
+      <div style={skBlock('50%', 20, radii.sm)} />
+      <div style={skBlock('40%', 14, radii.sm)} />
+      {/* Today's workout card */}
+      <div style={skBlock('100%', 110, radii.xl)} />
+      {/* 3-stat row */}
+      <div style={{ display: 'flex', gap: spacing.md }}>
+        {[0, 1, 2].map((i) => <div key={i} style={{ ...skBlock('100%', 70, radii.xl), flex: 1 }} />)}
+      </div>
+      {/* Recent activity label */}
+      <div style={skBlock(80, 14, radii.sm)} />
+      {/* Recent activity items */}
+      {[0, 1, 2].map((i) => <div key={i} style={skBlock('100%', 52, radii.md)} />)}
+    </div>
+  );
+}
+
+export function ProfileSkeleton() {
+  return (
+    <div style={{ ...wrap, alignItems: 'center' }}>
+      {/* Avatar */}
+      <div style={{ ...skBlock(80, 80), borderRadius: '50%', alignSelf: 'center' }} />
+      {/* Name */}
+      <div style={skBlock(120, 20, radii.sm)} />
+      {/* Subtitle */}
+      <div style={skBlock(80, 14, radii.sm)} />
+      {/* Section 1 */}
+      <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: spacing.sm }}>
+        <div style={skBlock(60, 12, radii.sm)} />
+        <div style={skBlock('100%', 130, radii.xxl)} />
+      </div>
+      {/* Section 2 */}
+      <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: spacing.sm }}>
+        <div style={skBlock(60, 12, radii.sm)} />
+        <div style={skBlock('100%', 130, radii.xxl)} />
+      </div>
+    </div>
+  );
+}

--- a/src/shared/theme/styles.ts
+++ b/src/shared/theme/styles.ts
@@ -712,6 +712,11 @@ export const globalCss = `
     to { opacity: 1; transform: translateY(0); }
   }
 
+  @keyframes skeletonPulse {
+    0%, 100% { background: #1a1a1a; }
+    50%       { background: #222; }
+  }
+
   @keyframes slideUp {
     from { transform: translateY(100%); }
     to { transform: translateY(0); }
@@ -762,9 +767,42 @@ export const globalCss = `
     animation: slideDown 0.25s ease-in both;
   }
 
-  /* Tab transition classes */
-  .tab-enter-right { animation: tabSlideLeft 0.25s ease both; }
-  .tab-enter-left { animation: tabSlideRight 0.25s ease both; }
+  /* Day navigation — keeps spatial slide metaphor (used by WorkoutView) */
+  .day-enter-right { animation: tabSlideLeft 0.2s ease both; }
+  .day-enter-left  { animation: tabSlideRight 0.2s ease both; }
+
+  /* Tab transitions — cross-fade (no spatial relationship between tabs) */
+  @keyframes tabFadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  @keyframes tabChildIn {
+    from { opacity: 0; transform: translateY(6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .tab-enter-right,
+  .tab-enter-left {
+    animation: tabFadeIn 150ms ease both;
+  }
+
+  .tab-enter-right > *,
+  .tab-enter-left > * {
+    animation: tabChildIn 200ms ease both;
+    animation-fill-mode: both;
+  }
+
+  .tab-enter-right > *:nth-child(1),
+  .tab-enter-left > *:nth-child(1) { animation-delay: 0ms; }
+  .tab-enter-right > *:nth-child(2),
+  .tab-enter-left > *:nth-child(2) { animation-delay: 80ms; }
+  .tab-enter-right > *:nth-child(3),
+  .tab-enter-left > *:nth-child(3) { animation-delay: 160ms; }
+  .tab-enter-right > *:nth-child(4),
+  .tab-enter-left > *:nth-child(4) { animation-delay: 240ms; }
+  .tab-enter-right > *:nth-child(5),
+  .tab-enter-left > *:nth-child(5) { animation-delay: 320ms; }
 
   /* Set completion micro-interactions */
   @keyframes setCountPop {


### PR DESCRIPTION
…lash)

- Replace translateX tab slide with 150ms cross-fade + per-child stagger (80ms delay increments) so tabs feel instant but alive
- Preserve spatial slide for workout day navigation via new day-enter-* classes
- Add 5 layout-matched skeleton screens (Home, Workout, Dashboard, Quick, Profile) with pulsing #1a1a1a→#222 cards as Suspense fallbacks, replacing the generic dot spinner
- Replace splash loading bar + dumbbell SVG with wordmark-only + red pulse ring; enforce 300ms minimum dwell before fade (0.15s) so the app never flashes blank