### PR TITLE
feat: fix workout day swipe and update partial status dot colour

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -12,7 +12,7 @@ import { MeasurementsModal } from '@/features/progress/MeasurementsModal';
 import type { QuickTemplate } from '@/data/quick-templates';
 import { useProfilePhoto } from '@/features/photos/ProfilePhotoContext';
 import { TIMINGS } from '@/shared/constants/timings';
-import { usePRCelebration, usePullToRefresh, useSwipeNavigation, useWorkoutStreak } from '@/shared/hooks';
+import { usePRCelebration, usePullToRefresh, useWorkoutStreak } from '@/shared/hooks';
 
 const WorkoutView = lazy(() => import('@/features/workout/WorkoutView').then((m) => ({ default: m.WorkoutView })));
 const Dashboard = lazy(() => import('@/features/progress/Dashboard').then((m) => ({ default: m.Dashboard })));
@@ -69,24 +69,6 @@ export function AppShell({ profile, onProfileUpdate }: { profile: UserProfile; o
     window.setTimeout(() => setTabTransition(null), TIMINGS.ANIMATION_NORMAL);
   }, [activeTab]);
 
-  const swipe = useSwipeNavigation({
-    enabled: activeTab === 'workout',
-    onSwipeLeft: () => {
-      const next = plan.dayIndex + 1;
-      if (next < plan.days.length) {
-        plan.setDayIndex(next);
-        workout.resetWorkoutState();
-      }
-    },
-    onSwipeRight: () => {
-      const prev = plan.dayIndex - 1;
-      if (prev >= 0) {
-        plan.setDayIndex(prev);
-        workout.resetWorkoutState();
-      }
-    },
-  });
-
   const [isRefreshing, setIsRefreshing] = useState(false);
   const pull = usePullToRefresh({
     enabled: activeTab === 'dashboard',
@@ -123,10 +105,10 @@ export function AppShell({ profile, onProfileUpdate }: { profile: UserProfile; o
 
       <main
         ref={mainRef}
-        style={{ ...S.main, paddingBottom: 'calc(80px + env(safe-area-inset-bottom, 0px))', transform: swipe.swipeOffset ? `translateX(${swipe.swipeOffset}px)` : undefined, transition: swipe.swipeOffset ? 'none' : 'transform 0.25s ease' }}
-        onTouchStart={activeTab === 'workout' ? swipe.onTouchStart : pull.onTouchStart}
-        onTouchMove={activeTab === 'workout' ? swipe.onTouchMove : pull.onTouchMove}
-        onTouchEnd={activeTab === 'workout' ? swipe.onTouchEnd : pull.onTouchEnd}
+        style={{ ...S.main, paddingBottom: 'calc(80px + env(safe-area-inset-bottom, 0px))' }}
+        onTouchStart={pull.onTouchStart}
+        onTouchMove={pull.onTouchMove}
+        onTouchEnd={pull.onTouchEnd}
       >
         {activeTab === 'dashboard' && (pull.pullDistance > 0 || isRefreshing) && <div style={{ ...S.pullRefresh, height: isRefreshing ? 50 : Math.min(pull.pullDistance, 60) }}><span style={{ ...S.pullRefreshSpinner, animation: isRefreshing ? 'pullRefreshSpin 0.8s linear infinite' : 'none' }}><Icon name="refresh" size={22} /></span></div>}
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,7 +5,6 @@ import { S, globalCss } from '@/shared/theme/styles';
 import { colors } from '@/shared/theme/tokens';
 import { getGreeting } from '@/shared/utils';
 import { useDemoMode } from '@/shared/demo/DemoModeContext';
-import { usePlan } from '@/features/training-plan/PlanContext';
 import { useWorkout } from '@/features/workout/WorkoutContext';
 import { useProgress } from '@/features/progress/progress.context';
 import { MeasurementsModal } from '@/features/progress/MeasurementsModal';
@@ -34,7 +33,6 @@ export function AppShell({ profile, onProfileUpdate }: { profile: UserProfile; o
   const demoMode = useDemoMode();
   const workout = useWorkout();
   const progress = useProgress();
-  const plan = usePlan();
   const { photo: profilePhoto } = useProfilePhoto();
   const { currentStreak } = useWorkoutStreak(workout.workoutHistory);
   const pr = usePRCelebration(workout.newPR, workout.dismissPR);

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -493,7 +493,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                   width: 6,
                   height: 6,
                   borderRadius: '50%',
-                  background: status === 'complete' ? '#34C759' : '#FF9500',
+                  background: status === 'complete' ? '#34C759' : '#FFD60A',
                 }} />
               )}
             </button>


### PR DESCRIPTION
Remove the duplicate useSwipeNavigation hook from AppShell that was attaching a second swipe handler to <main> on the workout tab. This caused a compounding translateX bug where the exercise list appeared to shift ~120 px during a drag (60 px from the outer <main> + 60 px from WorkoutView's inner handler) instead of the intended 60 px. WorkoutView already owns the full swipe → animation → day-change flow.

Also change the partial-completion day pill dot from orange (#FF9500) to yellow (#FFD60A) per the design spec.