### PR TITLE
fix: fix tab content stagger to animate sections rather than wrappers

### DIFF
--- a/src/shared/theme/styles.ts
+++ b/src/shared/theme/styles.ts
@@ -787,22 +787,22 @@ export const globalCss = `
     animation: tabFadeIn 150ms ease both;
   }
 
-  .tab-enter-right > *,
-  .tab-enter-left > * {
+  .tab-enter-right > * > *,
+  .tab-enter-left > * > * {
     animation: tabChildIn 200ms ease both;
     animation-fill-mode: both;
   }
 
-  .tab-enter-right > *:nth-child(1),
-  .tab-enter-left > *:nth-child(1) { animation-delay: 0ms; }
-  .tab-enter-right > *:nth-child(2),
-  .tab-enter-left > *:nth-child(2) { animation-delay: 80ms; }
-  .tab-enter-right > *:nth-child(3),
-  .tab-enter-left > *:nth-child(3) { animation-delay: 160ms; }
-  .tab-enter-right > *:nth-child(4),
-  .tab-enter-left > *:nth-child(4) { animation-delay: 240ms; }
-  .tab-enter-right > *:nth-child(5),
-  .tab-enter-left > *:nth-child(5) { animation-delay: 320ms; }
+  .tab-enter-right > * > *:nth-child(1),
+  .tab-enter-left > * > *:nth-child(1) { animation-delay: 0ms; }
+  .tab-enter-right > * > *:nth-child(2),
+  .tab-enter-left > * > *:nth-child(2) { animation-delay: 100ms; }
+  .tab-enter-right > * > *:nth-child(3),
+  .tab-enter-left > * > *:nth-child(3) { animation-delay: 200ms; }
+  .tab-enter-right > * > *:nth-child(4),
+  .tab-enter-left > * > *:nth-child(4) { animation-delay: 300ms; }
+  .tab-enter-right > * > *:nth-child(5),
+  .tab-enter-left > * > *:nth-child(5) { animation-delay: 400ms; }
 
   /* Set completion micro-interactions */
   @keyframes setCountPop {


### PR DESCRIPTION
Stagger CSS was targeting direct children of the tab wrapper (`.tab-enter-right > *`), but since Suspense renders no DOM node, the only direct child is each feature's root div — a single invisible wrapper. The stagger had no visible effect.

Changed selectors to `> * > *` (grandchildren) so the animation targets actual content sections within each tab (CalendarStrip, stat cards, exercise cards, etc.). Also updated delay increments from 80ms → 100ms per the spec.