### PR TITLE
Adjust exercise input constraints and weight increment precision

### DIFF
--- a/src/features/workout/ExerciseCard.tsx
+++ b/src/features/workout/ExerciseCard.tsx
@@ -199,7 +199,7 @@ export function ExerciseCard({
           ) : (
             <InlineEdit
               value={pe.weightKg}
-              step={2.5}
+              step={0.5}
               min={0}
               max={500}
               inputMode="decimal"
@@ -216,8 +216,8 @@ export function ExerciseCard({
           <InlineEdit
             value={pe.reps}
             step={1}
-            min={pe.repsMin ?? 1}
-            max={pe.repsMax ?? 30}
+            min={1}
+            max={100}
             inputMode="numeric"
             color={colors.text}
             onChange={val => onUpdateExercise(pe.id, { reps: val })}

--- a/src/features/workout/WorkoutView.tsx
+++ b/src/features/workout/WorkoutView.tsx
@@ -681,9 +681,9 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
             <h3 style={S.editTitle}>{editingExercise.exercise.name}</h3>
             {(['sets', 'reps', 'weightKg', 'restSeconds'] as const).map(f => {
               const label = f === 'sets' ? 'Sets' : f === 'reps' ? 'Reps' : f === 'weightKg' ? 'Weight (kg)' : 'Rest (sec)';
-              const step = f === 'weightKg' ? 2.5 : f === 'restSeconds' ? 15 : 1;
-              const min = f === 'restSeconds' ? 30 : f === 'weightKg' ? 0 : f === 'reps' ? (editingExercise.repsMin ?? 1) : 1;
-              const max = f === 'sets' ? 10 : f === 'reps' ? (editingExercise.repsMax ?? 30) : f === 'restSeconds' ? 300 : 500;
+              const step = f === 'weightKg' ? 0.5 : f === 'restSeconds' ? 15 : 1;
+              const min = f === 'restSeconds' ? 30 : f === 'weightKg' ? 0 : f === 'reps' ? 1 : 1;
+              const max = f === 'sets' ? 10 : f === 'reps' ? 100 : f === 'restSeconds' ? 300 : 500;
               return (
                 <div key={f} style={S.editField}>
                   <label style={S.editLabel}>{label}</label>
@@ -1104,7 +1104,7 @@ export function WorkoutView({ profile }: WorkoutViewProps) {
                             <input
                               type="number"
                               min={0}
-                              step={2.5}
+                              step={0.5}
                               value={de.weightKg}
                               onChange={e => updateDraftExerciseField(day.id, exerciseIndex, { weightKg: Math.max(0, Number(e.target.value)) })}
                               style={templatesCustomStyles.rowInput}

--- a/src/ui/modals/ExerciseEditModal.jsx
+++ b/src/ui/modals/ExerciseEditModal.jsx
@@ -16,15 +16,15 @@ export default function ExerciseEditModal({ exercise, onUpdate, onRemove, onClos
             <div style={S.editControls}>
               <button onClick={() => onUpdate(exercise.id, f,
                 Math.max(
-                  f === 'rest' ? 30 : f === 'weight' ? 0 : (f === 'reps' ? (exercise.repsMin ?? 1) : 1),
-                  exercise[f] - (f === 'weight' ? 2.5 : f === 'rest' ? 15 : 1)
+                  f === 'rest' ? 30 : f === 'weight' ? 0 : (f === 'reps' ? 1 : 1),
+                  exercise[f] - (f === 'weight' ? 0.5 : f === 'rest' ? 15 : 1)
                 )
               )} style={S.editBtn2}><Icon name="minus" size={16} /></button>
               <span style={S.editValue}>{exercise[f]}{f === 'rest' ? 's' : ''}</span>
               <button onClick={() => onUpdate(exercise.id, f,
                 Math.min(
-                  f === 'sets' ? 10 : (f === 'reps' ? (exercise.repsMax ?? 30) : f === 'rest' ? 300 : 500),
-                  exercise[f] + (f === 'weight' ? 2.5 : f === 'rest' ? 15 : 1)
+                  f === 'sets' ? 10 : (f === 'reps' ? 100 : f === 'rest' ? 300 : 500),
+                  exercise[f] + (f === 'weight' ? 0.5 : f === 'rest' ? 15 : 1)
                 )
               )} style={S.editBtn2}><Icon name="plus" size={16} /></button>
             </div>


### PR DESCRIPTION
## Summary
Updated exercise parameter constraints and weight adjustment increments across the workout UI to provide finer-grained control and more reasonable default limits.

## Key Changes
- **Weight increment precision**: Changed weight step from 2.5 kg to 0.5 kg in three locations (WorkoutView, ExerciseEditModal, ExerciseCard), allowing users to make smaller weight adjustments
- **Reps constraints**: Removed dynamic `repsMin` and `repsMax` references and replaced with fixed values (min: 1, max: 100) for consistency
- **Reps max limit**: Increased maximum reps from 30 to 100 to accommodate higher rep range exercises

## Implementation Details
- Changes applied consistently across multiple components:
  - `WorkoutView.tsx`: Exercise editing form and draft exercise inputs
  - `ExerciseEditModal.jsx`: Modal increment/decrement controls
  - `ExerciseCard.tsx`: Inline edit controls for exercise parameters
- The removal of dynamic `repsMin`/`repsMax` (which referenced `exercise.repsMin ?? 1` and `exercise.repsMax ?? 30`) simplifies the logic while providing more reasonable defaults for most users

https://claude.ai/code/session_019g5znKxoqqwsKsHxUgaHNq